### PR TITLE
Add highlight for food value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ This file provides guidance to AI agents when working with code in this reposito
 - `yarn build:css` - Minify CSS with CSSO (from styles.src.css to styles.css)
 - `yarn version` - Bump version in manifest.json and versions.json
 
+## General guidelines
+
+- IMPORTANT: After finishing your task, make sure to run `yarn build` and fix any introduced issues.
+
 ## Typescript & Testing
 
 - Strict null checks required (strictNullChecks: true)

--- a/FoodTrackerPlugin.ts
+++ b/FoodTrackerPlugin.ts
@@ -110,6 +110,10 @@ export default class FoodTrackerPlugin extends Plugin {
 			})
 		);
 
+		this.registerMarkdownPostProcessor(el => {
+			this.highlightFoodAmount(el);
+		});
+
 		// Initial tally update
 		void this.updateNutritionTally();
 	}
@@ -201,5 +205,21 @@ export default class FoodTrackerPlugin extends Plugin {
 			this.documentTallyElement.remove();
 			this.documentTallyElement = null;
 		}
+	}
+
+	highlightFoodAmount(el: HTMLElement): void {
+		const text = el.textContent?.trim();
+		if (!text) return;
+
+		const match = text.match(/^#food\s+\[\[[^\]]+\]\]\s+(\d+(?:\.\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))$/i);
+		if (!match) return;
+
+		const amount = match[1];
+		const html = el.innerHTML;
+		const idx = html.lastIndexOf(amount);
+		if (idx === -1) return;
+
+		el.innerHTML =
+			html.substring(0, idx) + `<span class="food-value">${amount}</span>` + html.substring(idx + amount.length);
 	}
 }

--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -18,6 +18,7 @@ module.exports = {
 		}
 		registerEvent() {}
 		registerEditorSuggest() {}
+		registerMarkdownPostProcessor() {}
 		addStatusBarItem() {
 			return {
 				setText: () => {},

--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -19,6 +19,7 @@ module.exports = {
 		registerEvent() {}
 		registerEditorSuggest() {}
 		registerMarkdownPostProcessor() {}
+		registerEditorExtension() {}
 		addStatusBarItem() {
 			return {
 				setText: () => {},

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -16,12 +16,8 @@ describe("FoodTrackerPlugin", () => {
 		expect(plugin.settings.nutrientDirectory).toBe("nutrients");
 	});
 
-	test("highlightFoodAmount wraps value", () => {
-		const el = document.createElement("p");
-		el.textContent = "#food [[apple]] 50g";
-
-		plugin.highlightFoodAmount(el);
-
-		expect(el.innerHTML).toBe('#food [[apple]] <span class="food-value">50g</span>');
+	test("createFoodHighlightExtension returns extension", () => {
+		const extension = plugin.createFoodHighlightExtension();
+		expect(extension).toBeDefined();
 	});
 });

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -15,9 +15,4 @@ describe("FoodTrackerPlugin", () => {
 		expect(plugin.settings).toBeDefined();
 		expect(plugin.settings.nutrientDirectory).toBe("nutrients");
 	});
-
-	test("createFoodHighlightExtension returns extension", () => {
-		const extension = plugin.createFoodHighlightExtension();
-		expect(extension).toBeDefined();
-	});
 });

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -15,4 +15,13 @@ describe("FoodTrackerPlugin", () => {
 		expect(plugin.settings).toBeDefined();
 		expect(plugin.settings.nutrientDirectory).toBe("nutrients");
 	});
+
+	test("highlightFoodAmount wraps value", () => {
+		const el = document.createElement("p");
+		el.textContent = "#food [[apple]] 50g";
+
+		plugin.highlightFoodAmount(el);
+
+		expect(el.innerHTML).toBe('#food [[apple]] <span class="food-value">50g</span>');
+	});
 });

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
 	},
 	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
 	"dependencies": {
+		"@codemirror/state": "^6.5.2",
+		"@codemirror/view": "^6.37.1",
 		"lodash": "^4.17.21"
 	}
 }

--- a/styles.src.css
+++ b/styles.src.css
@@ -56,3 +56,10 @@
 	color: var(--text-muted);
 	font-style: italic;
 }
+
+.food-value {
+	background-color: var(--color-green);
+	color: var(--background-primary);
+	border-radius: 4px;
+	padding: 0 4px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,6 +284,23 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@codemirror/state@^6.5.0", "@codemirror/state@^6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.5.2.tgz#8eca3a64212a83367dc85475b7d78d5c9b7076c6"
+  integrity sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
+"@codemirror/view@^6.37.1":
+  version "6.37.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.37.1.tgz#e769e69c9b3dd3080a65a18a72c07dc3fc8d036c"
+  integrity sha512-Qy4CAUwngy/VQkEz0XzMKVRcckQuqLYWKqVpDDDghBe5FSXSqfVrJn49nw3ePZHxRUz4nRmb05Lgi+9csWo4eg==
+  dependencies:
+    "@codemirror/state" "^6.5.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
 "@csstools/color-helpers@^5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.0.2.tgz#82592c9a7c2b83c293d9161894e2a6471feb97b8"
@@ -833,6 +850,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
+  integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1493,6 +1515,11 @@ create-jest@^29.7.0:
     jest-config "^29.7.0"
     jest-util "^29.7.0"
     prompts "^2.0.1"
+
+crelt@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
+  integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -3256,6 +3283,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+style-mod@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.2.tgz#ca238a1ad4786520f7515a8539d5a63691d7bf67"
+  integrity sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
@@ -3446,6 +3478,11 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- highlight parsed food amounts in preview
- update mock obsidian API for markdown postprocessors
- test highlightFoodAmount method
- style for the highlighted tag

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:dev`
- `yarn build:css`

------
https://chatgpt.com/codex/tasks/task_b_6846621b56b48332bd448e8fbc63c202