### PR TITLE
Add configurable food tag

### DIFF
--- a/FoodTrackerPlugin.ts
+++ b/FoodTrackerPlugin.ts
@@ -7,11 +7,13 @@ import NutritionTally from "./NutritionTally";
 interface FoodTrackerPluginSettings {
 	nutrientDirectory: string;
 	tallyDisplayMode: "status-bar" | "document";
+	foodTag: string;
 }
 
 const DEFAULT_SETTINGS: FoodTrackerPluginSettings = {
 	nutrientDirectory: "nutrients",
 	tallyDisplayMode: "status-bar",
+	foodTag: "#food",
 };
 
 export default class FoodTrackerPlugin extends Plugin {
@@ -33,7 +35,7 @@ export default class FoodTrackerPlugin extends Plugin {
 		this.registerEditorSuggest(this.foodSuggest);
 
 		// Initialize nutrition tally
-		this.nutritionTally = new NutritionTally(this.nutrientCache);
+		this.nutritionTally = new NutritionTally(this.nutrientCache, this.settings.foodTag);
 		this.statusBarItem = this.addStatusBarItem();
 		this.statusBarItem.setText("");
 
@@ -122,20 +124,17 @@ export default class FoodTrackerPlugin extends Plugin {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, (await this.loadData()) as Partial<FoodTrackerPluginSettings>);
 	}
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-		if (this.nutrientCache) {
-			this.nutrientCache.updateNutrientDirectory(this.settings.nutrientDirectory);
-		}
+       async saveSettings() {
+               await this.saveData(this.settings);
+               if (this.nutrientCache) {
+                       this.nutrientCache.updateNutrientDirectory(
+                               this.settings.nutrientDirectory,
+                       );
+               }
 
-		// Recreate nutrition tally with new directory
-		if (this.nutritionTally) {
-			this.nutritionTally = new NutritionTally(this.nutrientCache);
-		}
-
-		// Update tally display when settings change
-		void this.updateNutritionTally();
-	}
+               // Update tally display when settings change
+               void this.updateNutritionTally();
+       }
 
 	getNutrientNames(): string[] {
 		return this.nutrientCache.getNutrientNames();

--- a/FoodTrackerSettingTab.ts
+++ b/FoodTrackerSettingTab.ts
@@ -1,5 +1,6 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import type FoodTrackerPlugin from "./FoodTrackerPlugin";
+import NutritionTally from "./NutritionTally";
 export default class FoodTrackerSettingTab extends PluginSettingTab {
 	plugin: FoodTrackerPlugin;
 
@@ -35,5 +36,23 @@ export default class FoodTrackerSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+               new Setting(containerEl)
+                       .setName("Food tag")
+                       .setDesc("Tag used to mark food entries")
+                       .addText(text =>
+                               text
+                                       .setValue(this.plugin.settings.foodTag)
+                                       .onChange(async value => {
+                                               const tag = value.startsWith("#") ? value : `#${value}`;
+                                               this.plugin.settings.foodTag = tag;
+                                               this.plugin.foodSuggest.updateTagRegex(tag);
+                                               this.plugin.nutritionTally = new NutritionTally(
+                                                       this.plugin.nutrientCache,
+                                                       tag,
+                                               );
+                                               await this.plugin.saveSettings();
+                                       })
+                       );
 	}
 }

--- a/NutritionTally.ts
+++ b/NutritionTally.ts
@@ -17,11 +17,23 @@ interface FoodEntry {
 }
 
 export default class NutritionTally {
-	private nutrientCache: NutrientCache;
+       private nutrientCache: NutrientCache;
+       private foodTag: string;
+       private foodEntryRegex: RegExp;
 
-	constructor(nutrientCache: NutrientCache) {
-		this.nutrientCache = nutrientCache;
-	}
+       constructor(nutrientCache: NutrientCache, foodTag: string) {
+               this.nutrientCache = nutrientCache;
+               this.foodTag = foodTag;
+               this.foodEntryRegex = this.buildRegex(foodTag);
+       }
+
+       private buildRegex(tag: string): RegExp {
+               const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+               return new RegExp(
+                       `${escapedTag}\\s+\\[\\[([^\\]]+)\\]\\]\\s+(\\d+(?:\\.\\d+)?)(kg|lb|cups?|tbsp|tsp|ml|oz|g|l)`,
+                       "i",
+               );
+       }
 
 	calculateTotalNutrients(content: string): string {
 		try {
@@ -44,8 +56,7 @@ export default class NutritionTally {
 		const lines = content.split("\n");
 
 		for (const line of lines) {
-			// Match #food [[filename]] amount
-			const match = line.match(/#food\s+\[\[([^\]]+)\]\]\s+(\d+(?:\.\d+)?)(kg|lb|cups?|tbsp|tsp|ml|oz|g|l)/i);
+			const match = line.match(this.foodEntryRegex);
 			if (match) {
 				const filename = match[1];
 				const amount = parseFloat(match[2]);

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ An Obsidian plugin to track your food intake (calories, macronutrients) and nutr
 
 - **Add nutrients**: Create nutrient entries with detailed nutritional information through a convenient modal interface
 - **Configurable storage**: Set a custom directory for storing nutrient files
-- **Complete nutrition tracking**: Track calories, fats (total, saturated, unsaturated, omega-3), carbohydrates, sugar, fiber, protein, and sodium
+- **Autocomplete**: Suggest nutrient names automatically when typing the food tag
+- **Flexible tag**: Choose the tag used for food entries (default `#food`)
+- **Nutrition tally**: View calories, macros and more in the status bar or directly in the document
 - **Metadata format**: Stores nutritional data in YAML frontmatter for easy querying and analysis
 
 ## Installation
@@ -48,6 +50,8 @@ An Obsidian plugin to track your food intake (calories, macronutrients) and nutr
 Go to Settings > Food Tracker to configure:
 
 - **Nutrient directory**: Choose where nutrient files are stored (default: "nutrients")
+- **Food tag**: Tag that identifies food entries (default: `#food`)
+- **Nutrition tally display**: Show the daily total in the status bar or in the document
 
 ## Requirements
 

--- a/__tests__/NutritionTally.test.ts
+++ b/__tests__/NutritionTally.test.ts
@@ -11,7 +11,7 @@ describe("NutritionTally", () => {
 			getNutritionData: mockGetNutritionData,
 		} as unknown as NutrientCache;
 
-		nutritionTally = new NutritionTally(mockNutrientCache);
+		nutritionTally = new NutritionTally(mockNutrientCache, "#food");
 		jest.clearAllMocks();
 	});
 
@@ -25,6 +25,17 @@ describe("NutritionTally", () => {
 		test("returns empty string for empty content", () => {
 			const result = nutritionTally.calculateTotalNutrients("");
 			expect(result).toBe("");
+		});
+
+		test("supports custom tag", () => {
+			mockGetNutritionData.mockReturnValue({ calories: 50 });
+			const customTally = new NutritionTally(
+				{ getNutritionData: mockGetNutritionData } as unknown as NutrientCache,
+				"#eat"
+			);
+			const content = "#eat [[apple]] 100g";
+			const result = customTally.calculateTotalNutrients(content);
+			expect(result).toBe("📊 Daily tally: 🔥 50 kcal");
 		});
 
 		test("calculates total nutrients for single food entry", () => {


### PR DESCRIPTION
## Summary
- allow configuring the tag used for food entries
- update plugin settings UI
- adjust suggest and tally logic to use the configured tag
- document available features including the new setting
- expand tests for NutritionTally
- optimize escaping by compiling regex when the setting changes

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test:dev`


------
https://chatgpt.com/codex/tasks/task_b_6846601fdc2c833281bcac30162accf9