### PR TITLE
Fix highlight for amounts only within links

### DIFF
--- a/__tests__/FoodHighlightCore.test.ts
+++ b/__tests__/FoodHighlightCore.test.ts
@@ -83,13 +83,12 @@ describe("FoodHighlightCore", () => {
 				});
 			});
 
-			test("handles food names without brackets", () => {
-				const text = "#food Chicken 200g";
-				const ranges = extractFoodHighlightRanges(text, 0, defaultOptions);
+                       test("ignores amounts without brackets", () => {
+                               const text = "#food Chicken 200g";
+                               const ranges = extractFoodHighlightRanges(text, 0, defaultOptions);
 
-				expect(ranges).toHaveLength(1);
-				expect(ranges[0]).toEqual({ start: 14, end: 18, type: "amount" }); // 200g
-			});
+                               expect(ranges).toHaveLength(0);
+                       });
 
 			test("handles decimal amounts", () => {
 				const text = "#food [[Pasta]] 125.5g";

--- a/__tests__/FoodHighlightCore.test.ts
+++ b/__tests__/FoodHighlightCore.test.ts
@@ -83,12 +83,12 @@ describe("FoodHighlightCore", () => {
 				});
 			});
 
-                       test("ignores amounts without brackets", () => {
-                               const text = "#food Chicken 200g";
-                               const ranges = extractFoodHighlightRanges(text, 0, defaultOptions);
+			test("ignores amounts without brackets", () => {
+				const text = "#food Chicken 200g";
+				const ranges = extractFoodHighlightRanges(text, 0, defaultOptions);
 
-                               expect(ranges).toHaveLength(0);
-                       });
+				expect(ranges).toHaveLength(0);
+			});
 
 			test("handles decimal amounts", () => {
 				const text = "#food [[Pasta]] 125.5g";

--- a/constants.ts
+++ b/constants.ts
@@ -104,10 +104,7 @@ export const createLinkedFoodRegex = (escapedFoodTag: string) =>
  * ```
  */
 export const createLinkedFoodHighlightRegex = (escapedFoodTag: string) =>
-	new RegExp(
-                `#${escapedFoodTag}\\s+\\[[^\\]]+\\]\\]\\s+(\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`,
-		"i"
-	);
+	new RegExp(`#${escapedFoodTag}\\s+\\[[^\\]]+\\]\\]\\s+(\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`, "i");
 
 // ================================
 // Advanced highlighting regex patterns
@@ -125,7 +122,7 @@ const createInlineNutritionPattern = () =>
  * Example: "#food [[Chicken]] 200g"
  */
 const createLinkedFoodPattern = () =>
-        `\\[\\[[^\\]]+\\]\\]\\s+(?<amountValue>\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`;
+	`\\[\\[[^\\]]+\\]\\]\\s+(?<amountValue>\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`;
 /**
  * Combined regex for food highlighting that matches both inline nutrition and linked food patterns
  * Uses named capture groups to distinguish between different match types

--- a/constants.ts
+++ b/constants.ts
@@ -91,21 +91,21 @@ export const createLinkedFoodRegex = (escapedFoodTag: string) =>
 	new RegExp(`#${escapedFoodTag}\\s+\\[\\[([^\\]]+)\\]\\]\\s+(\\d+(?:\\.\\d+)?)(kg|lb|cups?|tbsp|tsp|ml|oz|g|l)`, "i");
 
 /**
- * Creates regex to match linked food entries for highlighting (broader pattern)
+ * Creates regex to match linked food entries for highlighting
  *
  * @param escapedFoodTag - The escaped food tag
- * @returns RegExp that matches linked or non-linked food with amounts
+ * @returns RegExp that matches linked food entries with amounts
  *
  * @example
  * ```typescript
  * const regex = createLinkedFoodHighlightRegex("food");
- * // Matches: "#food [[Apple]] 150g" or "#food Apple 150g"
+ * // Matches: "#food [[Apple]] 150g"
  * // Captures: ["150g"]
  * ```
  */
 export const createLinkedFoodHighlightRegex = (escapedFoodTag: string) =>
 	new RegExp(
-		`#${escapedFoodTag}\\s+(?:\\[\\[[^\\]]+\\]\\]|[^\\s]+)\\s+(\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`,
+                `#${escapedFoodTag}\\s+\\[[^\\]]+\\]\\]\\s+(\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`,
 		"i"
 	);
 
@@ -122,11 +122,10 @@ const createInlineNutritionPattern = () =>
 
 /**
  * Creates a regex pattern for linked food entries with amounts (internal helper)
- * Example: "#food [[Chicken]] 200g" or "#food Chicken 200g"
+ * Example: "#food [[Chicken]] 200g"
  */
 const createLinkedFoodPattern = () =>
-	`(?:\\[\\[[^\\]]+\\]\\]|[^\\s]+)\\s+(?<amountValue>\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`;
-
+        `\\[\\[[^\\]]+\\]\\]\\s+(?<amountValue>\\d+(?:\\.\\d+)?(?:kg|lb|cups?|tbsp|tsp|ml|oz|g|l))`;
 /**
  * Combined regex for food highlighting that matches both inline nutrition and linked food patterns
  * Uses named capture groups to distinguish between different match types


### PR DESCRIPTION
## Summary
- avoid highlighting amounts for unlinked text
- update regex patterns and tests

## Testing
- `yarn test:dev`

------
https://chatgpt.com/codex/tasks/task_b_684f19f94fc88332b00d2a7c78e3f1c3