### PR TITLE
Fix plugin unloading and enhance settings

### DIFF
--- a/src/FileSuggest.ts
+++ b/src/FileSuggest.ts
@@ -1,0 +1,25 @@
+import { App, TFile, AbstractInputSuggest } from "obsidian";
+
+export default class FileSuggest extends AbstractInputSuggest<TFile> {
+	constructor(
+		private appInstance: App,
+		private inputEl: HTMLInputElement
+	) {
+		super(appInstance, inputEl);
+	}
+
+	getSuggestions(query: string): TFile[] {
+		return this.appInstance.vault
+			.getMarkdownFiles()
+			.filter(file => file.path.toLowerCase().includes(query.toLowerCase()));
+	}
+
+	renderSuggestion(file: TFile, el: HTMLElement): void {
+		el.setText(file.path);
+	}
+
+	selectSuggestion(file: TFile): void {
+		this.inputEl.value = file.path;
+		this.inputEl.trigger("input");
+	}
+}

--- a/src/FolderSuggest.ts
+++ b/src/FolderSuggest.ts
@@ -1,0 +1,25 @@
+import { App, TFolder, AbstractInputSuggest } from "obsidian";
+
+export default class FolderSuggest extends AbstractInputSuggest<TFolder> {
+	constructor(
+		private appInstance: App,
+		private inputEl: HTMLInputElement
+	) {
+		super(appInstance, inputEl);
+	}
+
+	getSuggestions(query: string): TFolder[] {
+		return this.appInstance.vault
+			.getAllFolders()
+			.filter(folder => folder.path.toLowerCase().includes(query.toLowerCase()));
+	}
+
+	renderSuggestion(folder: TFolder, el: HTMLElement): void {
+		el.setText(folder.path || "/");
+	}
+
+	selectSuggestion(folder: TFolder): void {
+		this.inputEl.value = folder.path;
+		this.inputEl.trigger("input");
+	}
+}

--- a/src/FoodHighlightExtension.ts
+++ b/src/FoodHighlightExtension.ts
@@ -4,21 +4,24 @@ import { RangeSetBuilder } from "@codemirror/state";
 import { extractMultilineHighlightRanges } from "./FoodHighlightCore";
 import { SettingsService } from "./SettingsService";
 import { Subscription } from "rxjs";
+import { Component } from "obsidian";
 
 /**
  * CodeMirror extension that highlights food amounts and nutrition values in the editor
  * Provides visual feedback for food entries and nutritional data
  * Uses reactive food tag updates via SettingsService
  */
-export default class FoodHighlightExtension {
+export default class FoodHighlightExtension extends Component {
 	private settingsService: SettingsService;
 	private escapedFoodTag: string = "";
 	private subscription: Subscription;
 
 	constructor(settingsService: SettingsService) {
+		super();
 		this.settingsService = settingsService;
+	}
 
-		// Subscribe to food tag changes
+	onload() {
 		this.subscription = this.settingsService.escapedFoodTag$.subscribe(escapedFoodTag => {
 			this.escapedFoodTag = escapedFoodTag;
 		});
@@ -27,7 +30,7 @@ export default class FoodHighlightExtension {
 	/**
 	 * Clean up subscriptions when the extension is destroyed
 	 */
-	destroy(): void {
+	onunload(): void {
 		if (this.subscription) {
 			this.subscription.unsubscribe();
 		}
@@ -53,8 +56,7 @@ export default class FoodHighlightExtension {
 				}
 
 				update(update: ViewUpdate) {
-					// Only rebuild decorations when document content changes
-					if (update.docChanged) {
+					if (update.docChanged || update.viewportChanged) {
 						this.decorations = this.buildDecorations(update.view);
 					}
 				}

--- a/src/FoodTrackerSettingTab.ts
+++ b/src/FoodTrackerSettingTab.ts
@@ -1,5 +1,7 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting, normalizePath } from "obsidian";
 import type FoodTrackerPlugin from "./FoodTrackerPlugin";
+import FolderSuggest from "./FolderSuggest";
+import FileSuggest from "./FileSuggest";
 /**
  * Settings tab for configuring the Food Tracker plugin
  * Provides options for nutrient directory, display mode, and food tag
@@ -19,12 +21,13 @@ export default class FoodTrackerSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Nutrient directory")
 			.setDesc("Directory where nutrient files will be created")
-			.addText(text =>
+			.addText(text => {
 				text.setValue(this.plugin.settings.nutrientDirectory).onChange(async value => {
-					this.plugin.settings.nutrientDirectory = value;
+					this.plugin.settings.nutrientDirectory = normalizePath(value);
 					await this.plugin.saveSettings();
-				})
-			);
+				});
+				new FolderSuggest(this.app, text.inputEl);
+			});
 
 		new Setting(containerEl)
 			.setName("Nutrition total display")
@@ -53,14 +56,15 @@ export default class FoodTrackerSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Goals file")
 			.setDesc("File containing daily nutrition goals")
-			.addText(text =>
+			.addText(text => {
 				text
 					.setPlaceholder("nutrition-goals.md")
 					.setValue(this.plugin.settings.goalsFile)
 					.onChange(async value => {
-						this.plugin.settings.goalsFile = value;
+						this.plugin.settings.goalsFile = normalizePath(value);
 						await this.plugin.saveSettings();
-					})
-			);
+					});
+				new FileSuggest(this.app, text.inputEl);
+			});
 	}
 }

--- a/src/GoalsHighlightExtension.ts
+++ b/src/GoalsHighlightExtension.ts
@@ -4,13 +4,14 @@ import { RangeSetBuilder } from "@codemirror/state";
 import { extractMultilineGoalsHighlightRanges } from "./GoalsHighlightCore";
 import { SettingsService } from "./SettingsService";
 import { Subscription } from "rxjs";
+import { Component } from "obsidian";
 
 /**
  * CodeMirror extension that highlights values in goals files
  * Provides visual feedback for nutrition goal values
  * Improved performance by avoiding expensive file detection
  */
-export default class GoalsHighlightExtension {
+export default class GoalsHighlightExtension extends Component {
 	private settingsService: SettingsService;
 	private goalsFile: string = "";
 	private subscription: Subscription;
@@ -19,9 +20,11 @@ export default class GoalsHighlightExtension {
 		settingsService: SettingsService,
 		private getActiveFilePath: () => string | null
 	) {
+		super();
 		this.settingsService = settingsService;
+	}
 
-		// Subscribe to goals file changes
+	onload() {
 		this.subscription = this.settingsService.goalsFile$.subscribe(goalsFile => {
 			this.goalsFile = goalsFile;
 		});
@@ -30,7 +33,7 @@ export default class GoalsHighlightExtension {
 	/**
 	 * Clean up subscriptions when the extension is destroyed
 	 */
-	destroy(): void {
+	onunload(): void {
 		if (this.subscription) {
 			this.subscription.unsubscribe();
 		}
@@ -57,8 +60,7 @@ export default class GoalsHighlightExtension {
 				}
 
 				update(update: ViewUpdate) {
-					// Only rebuild decorations when document content changes
-					if (update.docChanged) {
+					if (update.docChanged || update.viewportChanged) {
 						this.decorations = this.buildDecorations(update.view);
 					}
 				}

--- a/src/__mocks__/obsidian.js
+++ b/src/__mocks__/obsidian.js
@@ -1,9 +1,20 @@
 // Mock for Obsidian API
 module.exports = {
+	Component: class Component {
+		addChild() {}
+		removeChild() {}
+		onload() {}
+		onunload() {}
+		load() {}
+		unload() {}
+		register() {}
+		registerEvent() {}
+	},
 	Plugin: class Plugin {
 		constructor(app, manifest) {
 			this.app = app;
 			this.manifest = manifest;
+			this._children = [];
 		}
 		loadData() {
 			return Promise.resolve({});
@@ -15,6 +26,14 @@ module.exports = {
 		addCommand() {}
 		addRibbonIcon() {
 			return {};
+		}
+		addChild(child) {
+			this._children.push(child);
+			if (typeof child.onload === "function") child.onload();
+		}
+		removeChild(child) {
+			this._children = this._children.filter(c => c !== child);
+			if (typeof child.onunload === "function") child.onunload();
 		}
 		registerEvent() {}
 		registerEditorSuggest() {}
@@ -105,6 +124,17 @@ module.exports = {
 		}
 		onTrigger() {
 			return null;
+		}
+		getSuggestions() {
+			return [];
+		}
+		renderSuggestion() {}
+		selectSuggestion() {}
+	},
+	AbstractInputSuggest: class AbstractInputSuggest {
+		constructor(app, inputEl) {
+			this.app = app;
+			this.inputEl = inputEl;
 		}
 		getSuggestions() {
 			return [];


### PR DESCRIPTION
## Summary
- register highlight extensions as plugin children
- add file and folder path suggestions
- normalize user paths and improve nutrient file creation
- use `requestUrl` for OpenFoodFacts integration
- refresh cache only once and update decorations on scroll
- update test mocks

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_687805b17c188332835840db289355c2