### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/forketyfork/obsidian-food-tracker/security/code-scanning/1](https://github.com/forketyfork/obsidian-food-tracker/security/code-scanning/1)

To address the issue, we will explicitly define permissions for the workflow at the root level. Since the workflow only reads from the repository (e.g., checking out code with `actions/checkout`), it requires only `contents: read` permissions. These permissions will be sufficient for the tasks outlined in the workflow while adhering to the principle of least privilege. We will add the `permissions` key at the root level of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
