### PR TITLE
Support piece weight and piece counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
 - **Configurable food tag**: Customize the tag used for food entries (default: `#food`, can be changed to `#meal`, `#nutrition`, etc.)
 - **Intelligent autocomplete**: Type your food tag followed by a food name for intelligent suggestions from your nutrient database
 - **Flexible food formats**: Multiple ways to track your food:
-  - **Database entries**: `#food [[food-name]] amount` - uses your nutrient database
+  - **Database entries**: `#food [[food-name]] amount` - uses your nutrient database. If the nutrient is measured per piece, omit the amount for a single piece or add a number for multiple pieces: `#food [[food-name]]` or `#food [[food-name]] 2`
   - **Inline nutrition**: `#food Food Name 300kcal 20fat 10prot 30carbs 3sugar` - specify nutrition directly
 - **Multiple units**: Support for various units including g, kg, ml, l, oz, lb, cup, tbsp, tsp
 - **Visual highlighting**: Food amounts and nutrition values are highlighted in the editor for easy identification
@@ -83,7 +83,9 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
      - Fats (in grams)
      - Carbohydrates, sugar, fiber (in grams)
      - Protein (in grams)
-     - Sodium (in milligrams)
+   - Sodium (in milligrams)
+   - **Measure**: Choose "100 grams" (default) or "piece"
+   - **Weight of a piece**: Optional, in grams; defaults to 100g if not specified
 4. Click "Create" to save the nutrient file
 
 ### Tracking Food Intake
@@ -97,7 +99,9 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
    #food [[apple]] 150g
    #food [[chicken-breast]] 200g
    #food [[oats]] 50g
+   #food [[banana]]
    ```
+   Use a bare wikilink when the nutrient is measured per piece, optionally followed by a number to specify multiple pieces.
 
 #### Method 2: Inline Nutrition Entry
 

--- a/src/NutrientCache.ts
+++ b/src/NutrientCache.ts
@@ -9,6 +9,8 @@ interface NutrientData {
 	fiber?: number;
 	sugar?: number;
 	sodium?: number;
+	measure?: "100 grams" | "piece";
+	weight?: number;
 }
 
 /**
@@ -177,7 +179,7 @@ export default class NutrientCache implements NutrientProvider {
 			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
 			if (!frontmatter) return {};
 
-			const nutrientFields: { key: keyof NutrientData; aliases: string[] }[] = [
+			const nutrientFields: { key: keyof Omit<NutrientData, "measure">; aliases: string[] }[] = [
 				{ key: "calories", aliases: ["calories"] },
 				{ key: "fats", aliases: ["fats"] },
 				{ key: "protein", aliases: ["protein"] },
@@ -185,6 +187,7 @@ export default class NutrientCache implements NutrientProvider {
 				{ key: "fiber", aliases: ["fiber"] },
 				{ key: "sugar", aliases: ["sugar"] },
 				{ key: "sodium", aliases: ["sodium"] },
+				{ key: "weight", aliases: ["weight"] },
 			];
 
 			const data: NutrientData = {};
@@ -193,6 +196,12 @@ export default class NutrientCache implements NutrientProvider {
 				const value = field.aliases.map(alias => frontmatter[alias] as unknown).find(v => v !== undefined);
 				if (value !== undefined) {
 					data[field.key] = this.parseNumber(value);
+				}
+			}
+			if (typeof frontmatter.measure === "string") {
+				const measure = frontmatter.measure.toLowerCase();
+				if (measure === "piece" || measure === "100 grams") {
+					data.measure = measure;
 				}
 			}
 			return data;

--- a/src/NutritionTotal.ts
+++ b/src/NutritionTotal.ts
@@ -1,6 +1,11 @@
 import NutrientCache from "./NutrientCache";
 import type { NutrientGoals } from "./GoalsService";
-import { SPECIAL_CHARS_REGEX, createInlineNutritionRegex, createLinkedFoodRegex } from "./constants";
+import {
+	SPECIAL_CHARS_REGEX,
+	createInlineNutritionRegex,
+	createLinkedFoodRegex,
+	createLinkedFoodPieceRegex,
+} from "./constants";
 import { FOOD_TRACKER_ICON_NAME } from "./icon";
 import { setIcon } from "obsidian";
 
@@ -12,12 +17,14 @@ interface NutrientData {
 	fiber?: number;
 	sugar?: number;
 	sodium?: number;
+	measure?: "100 grams" | "piece";
+	weight?: number;
 }
 
 interface FoodEntry {
 	filename: string;
-	amount: number;
-	unit: string;
+	amount?: number;
+	unit?: string;
 }
 
 interface InlineNutrientEntry {
@@ -83,6 +90,7 @@ export default class NutritionTotal {
 		const entries: FoodEntry[] = [];
 		const lines = content.split("\n");
 		const entryRegex = createLinkedFoodRegex(escapedFoodTag);
+		const pieceRegex = createLinkedFoodPieceRegex(escapedFoodTag);
 
 		for (const line of lines) {
 			const match = entryRegex.exec(line);
@@ -91,11 +99,15 @@ export default class NutritionTotal {
 				const amount = parseFloat(match[2]);
 				const unit = match[3].toLowerCase();
 
-				entries.push({
-					filename,
-					amount,
-					unit,
-				});
+				entries.push({ filename, amount, unit });
+				continue;
+			}
+
+			const pieceMatch = pieceRegex.exec(line);
+			if (pieceMatch) {
+				const filename = pieceMatch[1];
+				const amount = pieceMatch[2] ? parseFloat(pieceMatch[2]) : undefined;
+				entries.push({ filename, amount });
 			}
 		}
 
@@ -149,7 +161,7 @@ export default class NutritionTotal {
 	 */
 	private addNutrients(target: NutrientData, source: NutrientData, multiplier: number = 1): void {
 		// Get all keys from the source object
-		const keys = Object.keys(source) as Array<keyof NutrientData>;
+		const keys = Object.keys(source) as Array<keyof Omit<NutrientData, "measure" | "weight">>;
 		for (const key of keys) {
 			// Ensure both target and source have the property before adding
 			if (source[key] !== undefined) {
@@ -177,7 +189,7 @@ export default class NutritionTotal {
 		for (const entry of entries) {
 			const nutrients = this.getNutrientDataForFile(entry.filename);
 			if (nutrients) {
-				const multiplier = this.getMultiplier(entry.amount, entry.unit);
+				const multiplier = this.getMultiplier(entry.amount, entry.unit, nutrients.measure, nutrients.weight);
 				this.addNutrients(totals, nutrients, multiplier);
 			}
 		}
@@ -201,8 +213,22 @@ export default class NutritionTotal {
 	 * Handles weight and volume conversions with reasonable approximations
 	 * Volume units (cups, tbsp, tsp) are converted assuming water density (1ml ≈ 1g)
 	 */
-	private getMultiplier(amount: number, unit: string): number {
-		// Assume nutrient data is per 100g by default
+	private getMultiplier(
+		amount: number | undefined,
+		unit: string | undefined,
+		measure: "100 grams" | "piece" | undefined,
+		weight?: number
+	): number {
+		if (measure === "piece") {
+			const pieceWeight = weight ?? 100;
+			const pieces = amount ?? 1;
+			return (pieces * pieceWeight) / 100;
+		}
+
+		if (amount === undefined || !unit) {
+			return 0;
+		}
+
 		const baseAmount = 100;
 
 		switch (unit) {
@@ -231,7 +257,13 @@ export default class NutritionTotal {
 	}
 
 	private formatTotal(nutrients: NutrientData, goals?: NutrientGoals): HTMLElement | null {
-		const formatConfig: { key: keyof NutrientData; emoji: string; name: string; unit: string; decimals: number }[] = [
+		const formatConfig: {
+			key: keyof Omit<NutrientData, "measure" | "weight">;
+			emoji: string;
+			name: string;
+			unit: string;
+			decimals: number;
+		}[] = [
 			{ key: "calories", emoji: "🔥", name: "Calories", unit: "kcal", decimals: 0 },
 			{ key: "fats", emoji: "🥑", name: "Fats", unit: "g", decimals: 1 },
 			{ key: "protein", emoji: "🥩", name: "Protein", unit: "g", decimals: 1 },

--- a/src/__tests__/NutritionTotal.test.ts
+++ b/src/__tests__/NutritionTotal.test.ts
@@ -300,8 +300,10 @@ Some other text
 
 			const result = nutritionTotal.calculateTotalNutrients(content);
 
-			expect(mockGetNutritionData).toHaveBeenCalledTimes(1);
+			expect(mockGetNutritionData).toHaveBeenCalledTimes(3);
 			expect(mockGetNutritionData).toHaveBeenCalledWith("complete");
+			expect(mockGetNutritionData).toHaveBeenCalledWith("no-amount");
+			expect(mockGetNutritionData).toHaveBeenCalledWith("no-unit");
 			expectEmojis(result, "🔥");
 		});
 
@@ -314,6 +316,47 @@ Some other text
 			const result = nutritionTotal.calculateTotalNutrients(content);
 
 			expectEmojis(result, "🔥");
+		});
+
+		test("calculates nutrients for piece measure", () => {
+			mockGetNutritionData.mockReturnValue({ calories: 100, measure: "piece", weight: 120 });
+
+			const content = "#food [[banana]]";
+			const result = nutritionTotal.calculateTotalNutrients(content);
+
+			expect(mockGetNutritionData).toHaveBeenCalledWith("banana");
+			expectElementToContain(result, "Calories: 120 kcal");
+			expectEmojis(result, "🔥");
+		});
+
+		test("calculates nutrients for multiple pieces", () => {
+			mockGetNutritionData.mockReturnValue({ calories: 100, measure: "piece", weight: 120 });
+
+			const content = "#food [[banana]] 2";
+			const result = nutritionTotal.calculateTotalNutrients(content);
+
+			expect(mockGetNutritionData).toHaveBeenCalledWith("banana");
+			expectElementToContain(result, "Calories: 240 kcal");
+			expectEmojis(result, "🔥");
+		});
+
+		test("uses default weight when unspecified", () => {
+			mockGetNutritionData.mockReturnValue({ calories: 100, measure: "piece" });
+
+			const content = "#food [[banana]] 2";
+			const result = nutritionTotal.calculateTotalNutrients(content);
+
+			expectElementToContain(result, "Calories: 200 kcal");
+			expectEmojis(result, "🔥");
+		});
+
+		test("ignores entry without amount for gram measure", () => {
+			mockGetNutritionData.mockReturnValue({ calories: 50, measure: "100 grams" });
+
+			const content = "#food [[banana]]";
+			const result = nutritionTotal.calculateTotalNutrients(content);
+
+			expect(result).toBeNull();
 		});
 
 		test("formats calories as rounded integers", () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -113,6 +113,13 @@ export const createLinkedFoodRegex = (escapedFoodTag: string) =>
 	new RegExp(`#${escapedFoodTag}\\s+\\[\\[([^\\]]+)\\]\\]\\s+(\\d+(?:\\.\\d+)?)(kg|lb|cups?|tbsp|tsp|ml|oz|g|l)`, "i");
 
 /**
+ * Creates regex to match linked food entries without amounts
+ * Used for foods measured per piece
+ */
+export const createLinkedFoodPieceRegex = (escapedFoodTag: string) =>
+	new RegExp(`#${escapedFoodTag}\\s+\\[\\[([^\\]]+)\\]\\](?:\\s+(\\d+(?:\\.\\d+)?))?\\s*$`, "i");
+
+/**
  * Creates regex to match linked food entries for highlighting
  *
  * @param escapedFoodTag - The escaped food tag


### PR DESCRIPTION
## Summary
- add optional `weight` frontmatter field for piece-based nutrients
- parse `#food [[item]] 2` style entries and compute totals using per-piece weight (default 100g)
- document per-piece weight and quantity handling

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn prod`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_6886877159448332bfab19433bd88421