### PR TITLE
Set default serving size to 100g with validation

### DIFF
--- a/src/NutrientModal.ts
+++ b/src/NutrientModal.ts
@@ -70,7 +70,7 @@ export default class NutrientModal extends Modal {
 			fiber: 0,
 			protein: 0,
 			sodium: 0,
-			serving_size: 0,
+			serving_size: 100,
 		};
 	}
 
@@ -163,6 +163,11 @@ export default class NutrientModal extends Modal {
 
 	async createNutrientFile() {
 		if (!this.nutrientData.name.trim()) {
+			return;
+		}
+
+		if (this.nutrientData.serving_size <= 0) {
+			new Notice("Serving size must be a positive number", 5000);
 			return;
 		}
 

--- a/src/NutritionTotal.ts
+++ b/src/NutritionTotal.ts
@@ -203,7 +203,6 @@ export default class NutritionTotal {
 	 * Volume units (cups, tbsp, tsp) are converted assuming water density (1ml ≈ 1g)
 	 */
 	private getMultiplier(amount: number, unit: string, servingSize?: number): number {
-		// Assume nutrient data is per 100g by default
 		const baseAmount = 100;
 
 		switch (unit) {
@@ -212,7 +211,7 @@ export default class NutritionTotal {
 			case "kg":
 				return (amount * 1000) / baseAmount;
 			case "ml":
-				return amount / baseAmount; // Assume 1ml = 1g for simplicity
+				return amount / baseAmount;
 			case "l":
 				return (amount * 1000) / baseAmount;
 			case "oz":
@@ -221,19 +220,17 @@ export default class NutritionTotal {
 				return (amount * 453.6) / baseAmount;
 			case "cup":
 			case "cups":
-				return (amount * 240) / baseAmount; // 1 cup = 240ml ≈ 240g
+				return (amount * 240) / baseAmount;
 			case "tbsp":
-				return (amount * 15) / baseAmount; // 1 tablespoon = 15ml ≈ 15g
+				return (amount * 15) / baseAmount;
 			case "tsp":
-				return (amount * 5) / baseAmount; // 1 teaspoon = 5ml ≈ 5g
+				return (amount * 5) / baseAmount;
 			case "pc":
 			case "pcs":
-				if (servingSize && servingSize > 0) {
-					return (amount * servingSize) / baseAmount;
-				}
-				return amount / baseAmount;
+				const effectiveServingSize = servingSize && servingSize > 0 ? servingSize : 100;
+				return (amount * effectiveServingSize) / baseAmount;
 			default:
-				return amount / baseAmount; // Default to grams
+				return amount / baseAmount;
 		}
 	}
 


### PR DESCRIPTION
Prompt:
1. When I create a new nutrient, the `serving_size` value in the dialog is set to 0, which causes the serving size to be always 0 by default, if the user didn't fill out this field. Let's make it 100 (grams).
2. Validate this field, do not allow specifying non-positive value for the serving size.
3. When calculating the daily values, if the user specifies the pc value in the food line and the `serving_size` for a nutrient is absent or incorrect (not a positive number), assume 100 grams.

Solution:
- Changed the default serving_size value from 0 to 100 in NutrientModal constructor to provide a sensible default for new nutrients
- Added validation in createNutrientFile() to prevent creating nutrients with non-positive serving sizes, displaying a user-friendly notice if attempted
- Updated getMultiplier() in NutritionTotal to use 100g as the default when serving_size is missing or invalid for piece unit calculations
- Removed redundant comments for cleaner code