### PR TITLE
fix: replace non-standard event triggering and improve HTTP handling

### DIFF
--- a/src/FileSuggest.ts
+++ b/src/FileSuggest.ts
@@ -9,9 +9,8 @@ export default class FileSuggest extends AbstractInputSuggest<TFile> {
 	}
 
 	getSuggestions(query: string): TFile[] {
-		return this.appInstance.vault
-			.getMarkdownFiles()
-			.filter(file => file.path.toLowerCase().includes(query.toLowerCase()));
+		const trimmedQuery = query.trim().toLowerCase();
+		return this.appInstance.vault.getMarkdownFiles().filter(file => file.path.toLowerCase().includes(trimmedQuery));
 	}
 
 	renderSuggestion(file: TFile, el: HTMLElement): void {
@@ -20,6 +19,6 @@ export default class FileSuggest extends AbstractInputSuggest<TFile> {
 
 	selectSuggestion(file: TFile): void {
 		this.inputEl.value = file.path;
-		this.inputEl.trigger("input");
+		this.inputEl.dispatchEvent(new Event("input"));
 	}
 }

--- a/src/FolderSuggest.ts
+++ b/src/FolderSuggest.ts
@@ -9,9 +9,8 @@ export default class FolderSuggest extends AbstractInputSuggest<TFolder> {
 	}
 
 	getSuggestions(query: string): TFolder[] {
-		return this.appInstance.vault
-			.getAllFolders()
-			.filter(folder => folder.path.toLowerCase().includes(query.toLowerCase()));
+		const trimmedQuery = query.trim().toLowerCase();
+		return this.appInstance.vault.getAllFolders().filter(folder => folder.path.toLowerCase().includes(trimmedQuery));
 	}
 
 	renderSuggestion(folder: TFolder, el: HTMLElement): void {
@@ -20,6 +19,6 @@ export default class FolderSuggest extends AbstractInputSuggest<TFolder> {
 
 	selectSuggestion(folder: TFolder): void {
 		this.inputEl.value = folder.path;
-		this.inputEl.trigger("input");
+		this.inputEl.dispatchEvent(new Event("input"));
 	}
 }

--- a/src/NutrientModal.ts
+++ b/src/NutrientModal.ts
@@ -228,6 +228,10 @@ ${servingSizeLine}---
 
 			const response = await requestUrl({ url });
 
+			if (response.status !== 200) {
+				throw new Error(`HTTP error: ${response.status}`);
+			}
+
 			const data = response.json as OpenFoodFactsSearchResponse;
 
 			// Handle different response formats and limit to 5 results


### PR DESCRIPTION
Replace non-standard HTMLElement.trigger() with standard dispatchEvent() API in suggest components to prevent runtime issues. Add explicit HTTP status checking in OpenFoodFacts API calls for clearer error messages. Improve query handling by trimming whitespace in file and folder suggestions.