### PR TITLE
Add workout calorie tracking options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
   - **Inline nutrition**: `#food Food Name 300kcal 20fat 10prot 30carbs 3sugar` - specify nutrition directly
   - **Multiple units**: Support for various units including g, kg, ml, l, oz, lb, cup, tbsp, tsp, pc
 - **Visual highlighting**: Food amounts and nutrition values are highlighted in the editor for easy identification
+  - Blue highlighting for calorie intake and nutrition values
+  - Red highlighting for calorie burns (workout tag or negative calories)
+- **Workout logging**: Track exercise with a dedicated tag (default: `#workout`) or by entering negative calories to subtract
+  them from your totals
+  - Autocomplete only suggests calorie values for workout entries (no food names or other nutrients)
+  - Visual distinction: workout calories are highlighted in red to differentiate from food intake
 
 ### 📊 Real-time Nutrition Tracking
 
@@ -143,6 +149,31 @@ You can combine both methods in the same document:
 
 The nutrition total will automatically update as you add food entries using any method.
 
+### Logging Workouts
+
+Deduct workout calories from your daily totals in two ways:
+
+- Use the dedicated workout tag (default: `#workout`):
+
+  ```
+  #workout Morning run 230kcal
+  #workout Strength training 180kcal
+  ```
+
+  When you type `#workout` followed by a description and start typing numbers, autocomplete will suggest only calorie values (e.g., `300kcal`). Food names and other nutrition keywords are not available with the workout tag.
+
+  **Important:** Workout tags only accept positive calorie values. Negative values (e.g., `#workout running -200kcal`) are invalid and will be ignored in calculations and not highlighted. This ensures clear semantics: workout entries always represent calories burned.
+
+- Enter negative calories directly with your food tag for ad-hoc workout tracking:
+
+  ```
+  #food Evening yoga -120kcal
+  ```
+
+In both cases, the plugin subtracts the logged calories (and any other specified nutrients) from your daily totals. Calories logged with the workout tag or as negative values are **highlighted in red** in the editor to visually distinguish calorie burns from calorie intake (which is highlighted in blue).
+
+**Calorie floor:** Your total calorie count is always floored at 0. If your workout calories exceed your food intake, the plugin displays 0 kcal instead of a negative value, ensuring totals never go below zero.
+
 ### Setting Up Nutrition Goals
 
 1. Create a goals file in your vault (e.g., `nutrition-goals.md`)
@@ -179,9 +210,10 @@ Go to Settings > Food Tracker to configure:
 - **Nutrient directory**: Choose where nutrient files are stored (default: "nutrients"). The setting now offers type-ahead folder suggestions.
 - **Nutrition total display**: Choose to show the total in the status bar or directly in the document
 - **Food tag**: Customize the tag used for food entries (default: "food" for `#food`, can be changed to "meal" for `#meal`, "nutrition" for `#nutrition`, etc.)
+- **Workout tag**: Customize the tag used for workout entries (default: "workout" for `#workout`)
 - **Goals file**: Specify the path to your nutrition goals file (e.g., "nutrition-goals.md"). The field includes type-ahead file suggestions.
 
-> **Note**: When you change the food tag setting, the plugin will only recognize the new tag. Existing `#food` entries will need to be manually updated to use the new tag if you want them to be included in nutrition calculations.
+> **Note**: When you change the food or workout tag settings, the plugin will only recognize the new tags. Existing entries will need to be updated if you want them included in calculations.
 
 ## Requirements
 

--- a/src/FoodSuggest.ts
+++ b/src/FoodSuggest.ts
@@ -20,6 +20,7 @@ export default class FoodSuggest extends EditorSuggest<string> {
 	suggestionCore: FoodSuggestionCore;
 	private settingsService: SettingsService;
 	private currentContext?: "measure" | "nutrition";
+	private currentTagType?: "food" | "workout";
 
 	constructor(app: App, settingsService: SettingsService, nutrientCache: NutrientCache) {
 		super(app);
@@ -34,8 +35,9 @@ export default class FoodSuggest extends EditorSuggest<string> {
 
 		if (!trigger) return null;
 
-		// Store the context for use in getSuggestions
+		// Store the context and tag type for use in getSuggestions
 		this.currentContext = trigger.context;
+		this.currentTagType = trigger.tagType;
 
 		return {
 			start: { line: cursor.line, ch: trigger.startOffset },
@@ -45,7 +47,12 @@ export default class FoodSuggest extends EditorSuggest<string> {
 	}
 
 	getSuggestions(context: EditorSuggestContext): string[] {
-		return this.suggestionCore.getSuggestions(context.query, this.nutrientCache, this.currentContext);
+		return this.suggestionCore.getSuggestions(
+			context.query,
+			this.nutrientCache,
+			this.currentContext,
+			this.currentTagType
+		);
 	}
 
 	renderSuggestion(nutrient: string, el: HTMLElement): void {

--- a/src/FoodTrackerPlugin.ts
+++ b/src/FoodTrackerPlugin.ts
@@ -280,7 +280,9 @@ export default class FoodTrackerPlugin extends Plugin {
 				content,
 				this.settingsService.currentEscapedFoodTag,
 				true,
-				this.goalsService.currentGoals
+				this.goalsService.currentGoals,
+				this.settingsService.currentEscapedWorkoutTag,
+				true
 			);
 
 			if (this.settings.totalDisplayMode === "status-bar") {

--- a/src/FoodTrackerSettingTab.ts
+++ b/src/FoodTrackerSettingTab.ts
@@ -54,6 +54,16 @@ export default class FoodTrackerSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Workout tag")
+			.setDesc("Tag name for logging workouts (without #)")
+			.addText(text =>
+				text.setValue(this.plugin.settings.workoutTag).onChange(async value => {
+					this.plugin.settings.workoutTag = value || "workout";
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
 			.setName("Goals file")
 			.setDesc("File containing daily nutrition goals")
 			.addText(text => {

--- a/src/SettingsService.ts
+++ b/src/SettingsService.ts
@@ -6,6 +6,7 @@ export interface FoodTrackerPluginSettings {
 	nutrientDirectory: string;
 	totalDisplayMode: "status-bar" | "document";
 	foodTag: string;
+	workoutTag: string;
 	goalsFile: string;
 }
 
@@ -13,6 +14,7 @@ export const DEFAULT_SETTINGS: FoodTrackerPluginSettings = {
 	nutrientDirectory: "nutrients",
 	totalDisplayMode: "status-bar",
 	foodTag: "food",
+	workoutTag: "workout",
 	goalsFile: "nutrition-goals.md",
 };
 
@@ -38,10 +40,24 @@ export class SettingsService {
 	}
 
 	/**
+	 * Observable stream of the workout tag
+	 */
+	get workoutTag$(): Observable<string> {
+		return this.settings$.pipe(map(settings => settings.workoutTag));
+	}
+
+	/**
 	 * Observable stream of the escaped food tag (for regex usage)
 	 */
 	get escapedFoodTag$(): Observable<string> {
 		return this.foodTag$.pipe(map(foodTag => foodTag.replace(SPECIAL_CHARS_REGEX, "\\$&")));
+	}
+
+	/**
+	 * Observable stream of the escaped workout tag (for regex usage)
+	 */
+	get escapedWorkoutTag$(): Observable<string> {
+		return this.workoutTag$.pipe(map(workoutTag => workoutTag.replace(SPECIAL_CHARS_REGEX, "\\$&")));
 	}
 
 	/**
@@ -80,10 +96,24 @@ export class SettingsService {
 	}
 
 	/**
+	 * Get the current workout tag value synchronously
+	 */
+	get currentWorkoutTag(): string {
+		return this.currentSettings.workoutTag;
+	}
+
+	/**
 	 * Get the current escaped food tag value synchronously
 	 */
 	get currentEscapedFoodTag(): string {
 		return this.currentFoodTag.replace(SPECIAL_CHARS_REGEX, "\\$&");
+	}
+
+	/**
+	 * Get the current escaped workout tag value synchronously
+	 */
+	get currentEscapedWorkoutTag(): string {
+		return this.currentWorkoutTag.replace(SPECIAL_CHARS_REGEX, "\\$&");
 	}
 
 	/**
@@ -130,6 +160,13 @@ export class SettingsService {
 	 */
 	updateFoodTag(newFoodTag: string): void {
 		this.updateSetting("foodTag", newFoodTag);
+	}
+
+	/**
+	 * Updates the workout tag and notifies all subscribers
+	 */
+	updateWorkoutTag(newWorkoutTag: string): void {
+		this.updateSetting("workoutTag", newWorkoutTag);
 	}
 
 	/**

--- a/src/StatsService.ts
+++ b/src/StatsService.ts
@@ -57,7 +57,9 @@ export default class StatsService {
 						content,
 						this.settingsService.currentEscapedFoodTag,
 						true,
-						this.goalsService.currentGoals
+						this.goalsService.currentGoals,
+						this.settingsService.currentEscapedWorkoutTag,
+						true
 					);
 				} catch (error) {
 					console.error(`Error calculating nutrition stats for ${file.path} on ${dateStr}:`, error);

--- a/src/styles.src.css
+++ b/src/styles.src.css
@@ -132,6 +132,13 @@
 	padding: 0 4px;
 }
 
+.food-tracker-negative-kcal {
+	background-color: rgba(var(--color-red-rgb), 0.5);
+	color: var(--text-on-accent-inverted);
+	border-radius: 4px;
+	padding: 0 4px;
+}
+
 /* Fixed width for search button to prevent resizing */
 .food-tracker-search-button {
 	min-width: 110px;


### PR DESCRIPTION
## Summary
- add a configurable workout tag and subtract logged workout calories from daily totals
- allow negative inline nutrition values and update parsing/highlighting to recognize them
- document the workflow and expand unit tests for workout and negative calorie scenarios

## Testing
- yarn test
- yarn typecheck

------
https://chatgpt.com/codex/tasks/task_b_68fb3319cfd08332b540aab4312047bd