### PR TITLE
Always show comprehensive calorie breakdown when goals are set

### DIFF
--- a/src/NutritionTotal.ts
+++ b/src/NutritionTotal.ts
@@ -292,15 +292,9 @@ export default class NutritionTotal {
 								: "food-tracker-progress-yellow";
 
 					let goalTooltipText: string;
-					if (
-						config.key === "calories" &&
-						goal !== undefined &&
-						workoutTotals?.calories !== undefined &&
-						workoutTotals.calories > 0 &&
-						unclampedNutrients?.calories !== undefined
-					) {
-						const foodCalories = unclampedNutrients.calories + workoutTotals.calories;
-						const workoutCalories = workoutTotals.calories;
+					if (config.key === "calories" && goal !== undefined && unclampedNutrients?.calories !== undefined) {
+						const workoutCalories = workoutTotals?.calories ?? 0;
+						const foodCalories = unclampedNutrients.calories + workoutCalories;
 						const consumed = value;
 						const remaining = Math.max(0, goal - consumed);
 						const percentConsumed = actualPercent;
@@ -336,8 +330,6 @@ export default class NutritionTotal {
 							`   ${remainingStr.padStart(maxNumWidth)} ${config.unit} (${percentRemaining}% remaining)`,
 						].join("\n");
 						span.addClass("food-tracker-tooltip-multiline");
-					} else if (config.key === "calories" && goal !== undefined) {
-						goalTooltipText = `${config.name}: ${formattedValue} ${config.unit} (${actualPercent}% of ${goal} ${config.unit} goal)`;
 					} else {
 						goalTooltipText = `${config.name}: ${formattedValue} ${config.unit} (${actualPercent}% of ${goal} ${config.unit} goal)`;
 					}


### PR DESCRIPTION
Update calorie tooltip to always display the comprehensive breakdown format whenever nutritional goals are configured, even when there are no workout records. In that case, the workout line shows 0 kcal.

Changes:
- Remove condition requiring workout calories > 0
- Default workout calories to 0 when undefined (workoutTotals?.calories ?? 0)
- Simplify conditional logic by removing redundant else-if branch

Now the tooltip consistently shows:
```
  500 kcal (#food)
-    0 kcal (#workout)
  ----
  500 kcal (42% consumed)


 1200 kcal (goal)
- 500 kcal (consumed)
  ----
  700 kcal (58% remaining)
```

This provides better clarity about calorie tracking even without workouts.