### PR TITLE
Remove logo from nutrition statistics modal

### DIFF
--- a/Docs/PLAN.md
+++ b/Docs/PLAN.md
@@ -352,7 +352,6 @@ interface ExtendedNutrients {
 
 	other: {
 		cholesterol?: number; // mg
-		saturatedFat?: number; // g
 		transFat?: number; // g
 		monounsaturatedFat?: number; // g
 		polyunsaturatedFat?: number; // g

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
 
 - **Add nutrients**: Create nutrient entries with detailed nutritional information through a convenient modal interface
 - **OpenFoodFacts integration**: Search and import nutritional data from the OpenFoodFacts database
-- **Complete nutrition tracking**: Track calories, fats, carbohydrates, sugar, fiber, protein, and sodium
+- **Complete nutrition tracking**: Track calories, fats, saturated fats, carbohydrates, sugar, fiber, protein, and sodium
 - **Metadata format**: Stores nutritional data in YAML frontmatter for easy querying and analysis
 - **Configurable storage**: Set a custom directory for storing nutrient files
 
@@ -51,7 +51,7 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
 - **Compact visual display**: Clean nutrition bar with emoji indicators and progress bars
 - **Interactive tooltips**: Hover over nutrition indicators to see detailed values and goal progress
 - **Flexible display modes**: Show nutrition total in status bar or directly in the document
-- **Comprehensive metrics**: Track calories, fats, protein, carbohydrates, fiber, sugar, and sodium
+- **Comprehensive metrics**: Track calories, fats, saturated fats, protein, carbohydrates, fiber, sugar, and sodium
 - **Smart parsing**: Automatically detects and calculates nutrition from food entries throughout your notes
 
 ### 🎯 Nutrition Goals & Progress Tracking
@@ -61,7 +61,7 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
 - **Color-coded feedback**: Green (within 10% of goal), yellow (below 90%), red (exceeding goal)
 - **Compact nutrition bar**: Bordered container with emoji progress indicators separated by vertical lines
 - **Enhanced tooltips**: Detailed hover information shows values and goal completion percentages
-- **Flexible goal setting**: Set goals for calories, fats, protein, carbohydrates, fiber, sugar, and sodium
+- **Flexible goal setting**: Set goals for calories, fats, saturated fats, protein, carbohydrates, fiber, sugar, and sodium
 
 ### 📈 Monthly statistics
 
@@ -131,6 +131,7 @@ For quick tracking without creating database entries, specify nutrition values d
 
 - `kcal` - calories
 - `fat` - fats in grams
+- `satfat` - saturated fats in grams
 - `prot` - protein in grams
 - `carbs` - carbohydrates in grams
 - `sugar` - sugar in grams

--- a/src/FoodTrackerPlugin.ts
+++ b/src/FoodTrackerPlugin.ts
@@ -301,6 +301,7 @@ export default class FoodTrackerPlugin extends Plugin {
 				true,
 				this.goalsService.currentGoals,
 				this.settingsService.currentEscapedWorkoutTag,
+				true,
 				true
 			);
 

--- a/src/NutritionTotal.ts
+++ b/src/NutritionTotal.ts
@@ -62,7 +62,8 @@ export default class NutritionTotal {
 		escaped = false,
 		goals?: NutrientGoals,
 		workoutTag: string = "workout",
-		workoutTagEscaped?: boolean
+		workoutTagEscaped?: boolean,
+		showIcon: boolean = true
 	): HTMLElement | null {
 		try {
 			const tag = escaped ? foodTag : foodTag.replace(SPECIAL_CHARS_REGEX, "\\$&");
@@ -98,7 +99,7 @@ export default class NutritionTotal {
 			// Combine both totals
 			const combined = this.combineNutrients(totalNutrients, inlineTotals);
 			const clamped = this.clampNutrientsToZero(combined);
-			return this.formatTotal(clamped, goals, workoutTotals, foodTag, workoutTag, combined);
+			return this.formatTotal(clamped, goals, workoutTotals, foodTag, workoutTag, combined, showIcon);
 		} catch (error) {
 			console.error("Error calculating nutrition total:", error);
 			return null;
@@ -248,7 +249,8 @@ export default class NutritionTotal {
 		workoutTotals?: NutrientData,
 		foodTag?: string,
 		workoutTag?: string,
-		unclampedNutrients?: NutrientData
+		unclampedNutrients?: NutrientData,
+		showIcon: boolean = true
 	): HTMLElement | null {
 		const formatConfig: {
 			key: keyof Omit<NutrientData, "serving_size">;
@@ -352,15 +354,17 @@ export default class NutritionTotal {
 		// Create the main nutrition bar container
 		const container = createEl("div", { cls: "food-tracker-nutrition-bar" });
 
-		// Add the Food Tracker icon using Obsidian's registered icon
-		const iconContainer = createEl("span", { cls: ["food-tracker-icon", "food-tracker-tooltip-host"] });
-		iconContainer.setAttribute("data-food-tracker-tooltip", "Food tracker");
-		iconContainer.setAttribute("aria-label", "Food tracker");
-		setIcon(iconContainer, FOOD_TRACKER_ICON_NAME);
-		container.appendChild(iconContainer);
+		// Add the Food Tracker icon if showIcon is true
+		if (showIcon) {
+			const iconContainer = createEl("span", { cls: ["food-tracker-icon", "food-tracker-tooltip-host"] });
+			iconContainer.setAttribute("data-food-tracker-tooltip", "Food tracker");
+			iconContainer.setAttribute("aria-label", "Food tracker");
+			setIcon(iconContainer, FOOD_TRACKER_ICON_NAME);
+			container.appendChild(iconContainer);
 
-		// Add separator after icon
-		container.appendChild(createEl("div", { cls: "food-tracker-separator" }));
+			// Add separator after icon
+			container.appendChild(createEl("div", { cls: "food-tracker-separator" }));
+		}
 
 		// Add nutrient elements with separators between them
 		elements.forEach((element, index) => {

--- a/src/StatsService.ts
+++ b/src/StatsService.ts
@@ -59,7 +59,8 @@ export default class StatsService {
 						true,
 						this.goalsService.currentGoals,
 						this.settingsService.currentEscapedWorkoutTag,
-						true
+						true,
+						false
 					);
 				} catch (error) {
 					console.error(`Error calculating nutrition stats for ${file.path} on ${dateStr}:`, error);


### PR DESCRIPTION
Remove the food tracker icon from each nutrition bar in the statistics modal to reduce visual noise. The icon is still displayed in the status bar for identification.

Changes:
- Add showIcon parameter to calculateTotalNutrients method
- Update formatTotal to conditionally display icon
- Statistics modal now passes showIcon=false
- Status bar continues to show icon with showIcon=true
- Add saturated fats to README documentation
- Remove saturated fats from Docs/PLAN.md (already implemented)