### PR TITLE
fix: normalize wikilink aliases in nutrition totals calculation

### DIFF
--- a/src/FoodHighlightCore.ts
+++ b/src/FoodHighlightCore.ts
@@ -1,4 +1,5 @@
 import { createNutritionValueRegex, createCombinedFoodHighlightRegex, getUnitMultiplier } from "./constants";
+import { normalizeFilename } from "./NutritionCalculator";
 
 export interface HighlightRange {
 	start: number;
@@ -164,7 +165,7 @@ export function extractInlineCalorieAnnotations(
 				continue;
 			}
 
-			const normalizedFileName = rawFileName.split("|")[0].split("#")[0].split("/").pop()?.trim();
+			const normalizedFileName = normalizeFilename(rawFileName);
 			if (!normalizedFileName) {
 				continue;
 			}

--- a/src/NutritionCalculator.ts
+++ b/src/NutritionCalculator.ts
@@ -142,7 +142,11 @@ function parseFoodEntries(content: string, escapedFoodTag: string): FoodEntry[] 
 	for (const line of lines) {
 		const match = entryRegex.exec(line);
 		if (match) {
-			const filename = match[1];
+			const rawFilename = match[1];
+			const filename = normalizeFilename(rawFilename);
+			if (!filename) {
+				continue;
+			}
 			const amount = parseFloat(match[2]);
 			const unit = match[3].toLowerCase();
 
@@ -155,6 +159,10 @@ function parseFoodEntries(content: string, escapedFoodTag: string): FoodEntry[] 
 	}
 
 	return entries;
+}
+
+export function normalizeFilename(raw: string): string | undefined {
+	return raw.split("|")[0].split("#")[0].split("/").pop()?.trim();
 }
 
 function parseInlineNutrientEntries(content: string, escapedFoodTag: string): InlineNutrientEntry[] {


### PR DESCRIPTION
Food entries with custom display names (e.g., `[[bread|Slice]] 20g`) were not being included in total stats because the filename wasn't normalized to strip the alias. The inline calorie display worked correctly but used separate normalization logic.

- Extract shared `normalizeFilename()` that handles pipe aliases, heading links, and folder paths
- Apply normalization in `parseFoodEntries()` for stats calculation
- Reuse the same function in `FoodHighlightCore` for inline calories
- Add tests for wikilink alias and complex path normalization

Fixes #123 