### PR TITLE
feat: add barcode search support for OpenFoodFacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
 ### 🍎 Food Database Management
 
 - **Add nutrients**: Create nutrient entries with detailed nutritional information through a convenient modal interface
-- **OpenFoodFacts integration**: Search and import nutritional data from the OpenFoodFacts database
+- **OpenFoodFacts integration**: Search and import nutritional data from the OpenFoodFacts database by product name or barcode
 - **Complete nutrition tracking**: Track calories, fats, saturated fats, carbohydrates, sugar, fiber, protein, and sodium
 - **Metadata format**: Stores nutritional data in YAML frontmatter for easy querying and analysis
 - **Configurable storage**: Set a custom directory for storing nutrient files
@@ -93,8 +93,10 @@ This plugin works on **mobile** and **desktop**, with layouts that adapt to smal
 1. Open the command palette (Ctrl/Cmd + P)
 2. Search for "Add nutrient" and select the command
 3. Fill in the nutrient information in the modal:
-   - **Name** (required)
+   - **Name or barcode** (required)
    - **🔍 Search**: Use the search button to find foods in OpenFoodFacts database
+     - Enter a product name to search by text
+     - Enter a barcode (8-14 digits) to look up by barcode (EAN-8, UPC-A, EAN-13, ITF-14)
    - **Nutritional values per 100g**:
      - Calories
      - Fats (in grams)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -180,6 +180,32 @@ export const createCombinedFoodHighlightRegex = (escapedFoodTag: string, escaped
 };
 
 // ================================
+// Barcode detection utilities
+// ================================
+
+/** Regex to match barcode formats (EAN-8, UPC-A, EAN-13, ITF-14) */
+export const BARCODE_REGEX = /^\d{8,14}$/;
+
+/**
+ * Checks if input looks like a barcode (8-14 digits)
+ * Supports EAN-8, UPC-A (12), EAN-13, and ITF-14 formats
+ *
+ * @param input - The string to check
+ * @returns true if the input matches barcode format
+ *
+ * @example
+ * ```typescript
+ * isBarcode("3017624010701") // true (EAN-13)
+ * isBarcode("12345678") // true (EAN-8)
+ * isBarcode("Nutella") // false
+ * isBarcode("123") // false (too short)
+ * ```
+ */
+export function isBarcode(input: string): boolean {
+	return BARCODE_REGEX.test(input.trim());
+}
+
+// ================================
 // Unit conversion utilities
 // ================================
 


### PR DESCRIPTION
Users can now search by product barcode (8-14 digits) in addition to product name. The plugin automatically detects if the input looks like a barcode and routes to the appropriate API endpoint.

- Add `isBarcode()` utility function for barcode detection
- Add `searchByBarcode()` using OpenFoodFacts v2 API
- Handle 404 gracefully as "no results" instead of error
- Update UI label to "Name or barcode"
- Add comprehensive unit tests for barcode detection

Fixes #124 