### PR TITLE
Move inline styles to CSS class

### DIFF
--- a/src/FoodTrackerSettingTab.ts
+++ b/src/FoodTrackerSettingTab.ts
@@ -155,12 +155,10 @@ export default class FoodTrackerSettingTab extends PluginSettingTab {
 			cls: "food-tracker-settings-collapsible-summary",
 		});
 
-		const descEl = detailsEl.createEl("p", {
+		detailsEl.createEl("p", {
 			cls: "food-tracker-settings-collapsible-desc setting-item-description",
 			text: "Customize the frontmatter field names used to store nutrition totals in daily notes.",
 		});
-		descEl.style.marginTop = "0.5em";
-		descEl.style.marginBottom = "1em";
 
 		const fieldConfigs: Array<{
 			key: keyof FrontmatterFieldNames;

--- a/src/styles.src.css
+++ b/src/styles.src.css
@@ -163,6 +163,11 @@
 	border-color: rgb(var(--color-red-rgb));
 }
 
+.food-tracker-settings-collapsible-desc {
+	margin-top: 0.5em;
+	margin-bottom: 1em;
+}
+
 /* Fixed width for search button to prevent resizing */
 .food-tracker-search-button {
 	min-width: 110px;


### PR DESCRIPTION
## Summary

Replace JavaScript inline style assignments with CSS class styling in FoodTrackerSettingTab to comply with project guidelines.

## Changes

- **`src/FoodTrackerSettingTab.ts`**: Removed `descEl.style.marginTop` and `descEl.style.marginBottom` inline style assignments
- **`src/styles.src.css`**: Added `.food-tracker-settings-collapsible-desc` CSS class with the margin styles

## Why

The project's CLAUDE.md guidelines specify:
> **Avoid inline styles**: Never assign styles via JavaScript (`element.style.x = y`) or inline HTML style attributes. Move all styles to CSS so themes and snippets can adapt them.

This change ensures themes and CSS snippets can override these styles if needed.