### PR TITLE
Use yarn install --immutable in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: "24.x"
       - name: Build plugin
         run: |
-          yarn install
+          yarn install --immutable
           yarn build
       - name: Fail if build modified files
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: "24.x"
       - name: Build plugin
         run: |
-          yarn install
+          yarn install --immutable
           yarn build
       - name: Fail if build modified files
         run: |


### PR DESCRIPTION
## Summary

- Use `yarn install --immutable` in CI workflows (`build.yml`, `publish.yml`) to ensure builds fail on lockfile mismatches instead of silently updating dependencies

## Notes

- The `obsidian` package requests exact older versions of `@codemirror/state` and `@codemirror/view` as peer dependencies, but the plugin code uses APIs from newer versions. The peer dep warnings are cosmetic and harmless.
