### PR TITLE
docs: add saturated_fats to nutrition goals example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ In both cases, the plugin subtracts the logged calories (and any other specified
    ```
    calories: 2000
    fats: 70
+   saturated_fats: 20
    protein: 120
    carbs: 250
    fiber: 25


### PR DESCRIPTION
## Summary

Fixes #227.

The nutrition goals example in the README was missing `saturated_fats`, so users had no way to discover the correct key name for setting a saturated fats goal. The code supports it, it just wasn't documented.

Added `saturated_fats: 20` to the example goals block alongside the other nutrients.
