### PR TITLE
fix(nutrients): stabilize cache startup and note refresh

### DIFF
--- a/src/FoodTrackerPlugin.ts
+++ b/src/FoodTrackerPlugin.ts
@@ -45,9 +45,7 @@ export default class FoodTrackerPlugin extends Plugin {
 	 * Initialize core services and components
 	 */
 	private initializeCore(): void {
-		// Initialize nutrient cache
 		this.nutrientCache = new NutrientCache(this.app, this.settings.nutrientDirectory);
-		this.nutrientCache.initialize();
 
 		// Initialize settings service
 		this.settingsService = new SettingsService();
@@ -63,9 +61,11 @@ export default class FoodTrackerPlugin extends Plugin {
 		// Register commands and tabs
 		this.registerCommandsAndTabs();
 
-		// Delay goals loading until vault is ready
+		// Delay cache initialization and note refresh until the workspace layout is ready
 		this.app.workspace.onLayoutReady(() => {
+			this.nutrientCache.initialize();
 			void this.goalsService.loadGoals();
+			this.refreshActiveNoteFrontmatterTotals();
 			// Update nutrition totals when workspace is ready
 			void this.updateNutritionTotal();
 		});
@@ -190,6 +190,7 @@ export default class FoodTrackerPlugin extends Plugin {
 
 		const onResolved = () => {
 			this.nutrientCache.refresh();
+			this.refreshActiveNoteFrontmatterTotals();
 			void this.updateNutritionTotal();
 			this.app.metadataCache.off("resolved", onResolved);
 		};
@@ -357,5 +358,14 @@ export default class FoodTrackerPlugin extends Plugin {
 	private clearTotal(): void {
 		if (this.statusBarItem) this.statusBarItem.setText("");
 		this.documentTotalManager.remove();
+	}
+
+	private refreshActiveNoteFrontmatterTotals(): void {
+		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+		const activeFile = activeView?.file;
+
+		if (activeFile instanceof TFile) {
+			this.frontmatterTotalsService.updateFrontmatterTotals(activeFile);
+		}
 	}
 }

--- a/src/FoodTrackerPlugin.ts
+++ b/src/FoodTrackerPlugin.ts
@@ -62,9 +62,9 @@ export default class FoodTrackerPlugin extends Plugin {
 		this.registerCommandsAndTabs();
 
 		// Delay cache initialization and note refresh until the workspace layout is ready
-		this.app.workspace.onLayoutReady(() => {
+		this.app.workspace.onLayoutReady(async () => {
 			this.nutrientCache.initialize();
-			void this.goalsService.loadGoals();
+			await this.goalsService.loadGoals();
 			this.refreshActiveNoteFrontmatterTotals();
 			// Update nutrition totals when workspace is ready
 			void this.updateNutritionTotal();

--- a/src/FrontmatterTotalsService.ts
+++ b/src/FrontmatterTotalsService.ts
@@ -73,17 +73,13 @@ export function applyNutrientTotalsToFrontmatter(
 ): void {
 	const keys = Object.keys(fieldNames) as FrontmatterKey[];
 
-	if (!totals) {
+	if (!totals || Object.keys(totals).length === 0) {
 		for (const key of keys) {
 			const frontmatterKey = fieldNames[key];
 			if (frontmatterKey in frontmatter) {
 				frontmatter[frontmatterKey] = 0;
 			}
 		}
-		return;
-	}
-
-	if (Object.keys(totals).length === 0) {
 		return;
 	}
 
@@ -177,15 +173,26 @@ export default class FrontmatterTotalsService {
 		this.activeUpdates.add(file.path);
 		try {
 			const content = await this.app.vault.cachedRead(file);
+			const pendingMetadataLookups = new Set<string>();
 			const result = calculateNutritionTotals({
 				content,
 				foodTag: this.settingsService.currentEscapedFoodTag,
 				escapedFoodTag: true,
 				workoutTag: this.settingsService.currentEscapedWorkoutTag,
 				workoutTagEscaped: true,
-				getNutritionData: (filename: string) => this.nutrientCache.getNutritionData(filename),
+				getNutritionData: (filename: string) => {
+					const nutrientData = this.nutrientCache.getNutritionData(filename);
+					if (!nutrientData && this.nutrientCache.hasPendingMetadataFor(filename)) {
+						pendingMetadataLookups.add(filename);
+					}
+					return nutrientData;
+				},
 				goals: this.goalsService.currentGoals,
 			});
+
+			if (pendingMetadataLookups.size > 0) {
+				return;
+			}
 
 			this.filesBeingWritten.add(file.path);
 			try {

--- a/src/FrontmatterTotalsService.ts
+++ b/src/FrontmatterTotalsService.ts
@@ -73,13 +73,17 @@ export function applyNutrientTotalsToFrontmatter(
 ): void {
 	const keys = Object.keys(fieldNames) as FrontmatterKey[];
 
-	if (!totals || Object.keys(totals).length === 0) {
+	if (!totals) {
 		for (const key of keys) {
 			const frontmatterKey = fieldNames[key];
 			if (frontmatterKey in frontmatter) {
 				frontmatter[frontmatterKey] = 0;
 			}
 		}
+		return;
+	}
+
+	if (Object.keys(totals).length === 0) {
 		return;
 	}
 
@@ -107,7 +111,9 @@ export default class FrontmatterTotalsService {
 	private goalsService: GoalsService;
 	private dailyNoteLocator: DailyNoteLocator;
 	private pendingUpdates: Map<string, NodeJS.Timeout> = new Map();
+	private activeUpdates: Set<string> = new Set();
 	private filesBeingWritten: Set<string> = new Set();
+	private queuedUpdates: Set<string> = new Set();
 	private debounceMs = 500;
 
 	constructor(app: App, nutrientCache: NutrientCache, settingsService: SettingsService, goalsService: GoalsService) {
@@ -126,14 +132,30 @@ export default class FrontmatterTotalsService {
 	}
 
 	updateFrontmatterTotals(file: TFile): void {
+		this.requestUpdate(file, false);
+	}
+
+	private requestUpdate(file: TFile, queueWhileWriting: boolean): void {
 		if (!this.isDailyNote(file)) {
 			return;
 		}
 
 		if (this.filesBeingWritten.has(file.path)) {
+			if (queueWhileWriting) {
+				this.queuedUpdates.add(file.path);
+			}
 			return;
 		}
 
+		if (this.activeUpdates.has(file.path)) {
+			this.queuedUpdates.add(file.path);
+			return;
+		}
+
+		this.scheduleUpdate(file);
+	}
+
+	private scheduleUpdate(file: TFile): void {
 		const existingTimeout = this.pendingUpdates.get(file.path);
 		if (existingTimeout) {
 			clearTimeout(existingTimeout);
@@ -141,6 +163,10 @@ export default class FrontmatterTotalsService {
 
 		const timeout = setTimeout(() => {
 			this.pendingUpdates.delete(file.path);
+			if (this.activeUpdates.has(file.path) || this.filesBeingWritten.has(file.path)) {
+				this.queuedUpdates.add(file.path);
+				return;
+			}
 			void this.performUpdate(file);
 		}, this.debounceMs);
 
@@ -148,6 +174,7 @@ export default class FrontmatterTotalsService {
 	}
 
 	private async performUpdate(file: TFile): Promise<void> {
+		this.activeUpdates.add(file.path);
 		try {
 			const content = await this.app.vault.cachedRead(file);
 			const result = calculateNutritionTotals({
@@ -170,6 +197,11 @@ export default class FrontmatterTotalsService {
 			}
 		} catch (error) {
 			console.error(`Error updating frontmatter totals for ${file.path}:`, error);
+		} finally {
+			this.activeUpdates.delete(file.path);
+			if (this.queuedUpdates.delete(file.path)) {
+				this.scheduleUpdate(file);
+			}
 		}
 	}
 
@@ -182,6 +214,7 @@ export default class FrontmatterTotalsService {
 			clearTimeout(timeout);
 		}
 		this.pendingUpdates.clear();
+		this.queuedUpdates.clear();
 	}
 
 	updateNotesReferencingNutrient(nutrientBasename: string): void {
@@ -205,7 +238,7 @@ export default class FrontmatterTotalsService {
 			});
 
 			if (referencesNutrient) {
-				this.updateFrontmatterTotals(file);
+				this.requestUpdate(file, true);
 			}
 		}
 	}

--- a/src/NutrientCache.ts
+++ b/src/NutrientCache.ts
@@ -43,6 +43,7 @@ export default class NutrientCache implements NutrientProvider {
 	private nutrientDataCache: Map<string, { name: string; data: NutrientData }> = new Map(); // file path -> { name, data }
 	private nameToPathMap: Map<string, string> = new Map(); // nutrient name -> file path
 	private changeListeners: Set<() => void> = new Set();
+	private pendingMetadataFiles: Set<string> = new Set();
 
 	constructor(app: App, nutrientDirectory: string) {
 		this.app = app;
@@ -76,6 +77,7 @@ export default class NutrientCache implements NutrientProvider {
 	initialize(): void {
 		this.nutrientDataCache.clear();
 		this.nameToPathMap.clear();
+		this.pendingMetadataFiles.clear();
 
 		try {
 			const allMarkdownFiles = this.app.vault.getMarkdownFiles();
@@ -96,6 +98,7 @@ export default class NutrientCache implements NutrientProvider {
 	 * Used by delete operations and when files lose valid nutrient names
 	 */
 	private removeFileFromCache(filePath: string): void {
+		this.pendingMetadataFiles.delete(filePath);
 		const cachedEntry = this.nutrientDataCache.get(filePath);
 		if (cachedEntry) {
 			this.nameToPathMap.delete(cachedEntry.name);
@@ -111,9 +114,11 @@ export default class NutrientCache implements NutrientProvider {
 		const fileCache = this.app.metadataCache.getFileCache(file);
 		if (!fileCache) {
 			// Metadata cache is not ready yet; keep existing entry until it's available
+			this.pendingMetadataFiles.add(file.path);
 			return;
 		}
 
+		this.pendingMetadataFiles.delete(file.path);
 		const nutrientName = this.extractNutrientName(fileCache, file.path);
 		const nutritionData = this.extractNutritionData(fileCache, file.path);
 
@@ -248,6 +253,21 @@ export default class NutrientCache implements NutrientProvider {
 		return 0;
 	}
 
+	hasPendingMetadataFor(filename: string): boolean {
+		const normalizedFilename = filename.trim().toLowerCase();
+		if (!normalizedFilename) {
+			return false;
+		}
+
+		for (const filePath of this.pendingMetadataFiles) {
+			if (this.getBasenameWithoutExtension(filePath).toLowerCase() === normalizedFilename) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * Gets all available nutrient names in alphabetical order
 	 * Used for autocomplete and suggestion systems
@@ -282,8 +302,7 @@ export default class NutrientCache implements NutrientProvider {
 		if (!filePath) return null;
 
 		// Extract basename from path for backward compatibility
-		const parts = filePath.split("/");
-		return parts[parts.length - 1].replace(".md", "");
+		return this.getBasenameWithoutExtension(filePath);
 	}
 
 	/**
@@ -304,12 +323,17 @@ export default class NutrientCache implements NutrientProvider {
 	getNutritionData(filename: string): NutrientData | null {
 		// Try direct lookup by filename (basename without .md)
 		for (const [path, entry] of this.nutrientDataCache) {
-			const basename = path.split("/").pop()?.replace(".md", "");
+			const basename = this.getBasenameWithoutExtension(path);
 			if (basename === filename) {
 				return entry.data;
 			}
 		}
 		return null;
+	}
+
+	private getBasenameWithoutExtension(filePath: string): string {
+		const basename = filePath.split("/").pop() ?? filePath;
+		return basename.replace(/\.md$/i, "");
 	}
 
 	updateNutrientDirectory(newDirectory: string): void {

--- a/src/__mocks__/obsidian.js
+++ b/src/__mocks__/obsidian.js
@@ -256,6 +256,7 @@ module.exports = {
 					openFile: () => Promise.resolve(),
 				}),
 				getActiveViewOfType: () => null,
+				iterateAllLeaves: () => {},
 				on: () => ({}),
 				onLayoutReady: callback => {
 					// Call callback immediately in test environment

--- a/src/__tests__/FrontmatterTotalsService.test.ts
+++ b/src/__tests__/FrontmatterTotalsService.test.ts
@@ -338,14 +338,14 @@ describe("FrontmatterTotalsService", () => {
 				expect(frontmatter.title).toBe("My Note");
 			});
 
-			test("preserves existing values when totals is an empty object", () => {
+			test("sets existing values to 0 when totals is an empty object", () => {
 				const frontmatter: Record<string, unknown> = {
 					"ft-calories": 1000,
 				};
 
 				applyNutrientTotalsToFrontmatter(frontmatter, {});
 
-				expect(frontmatter["ft-calories"]).toBe(1000);
+				expect(frontmatter["ft-calories"]).toBe(0);
 				expect(frontmatter["ft-protein"]).toBeUndefined();
 			});
 
@@ -660,6 +660,80 @@ describe("FrontmatterTotalsService", () => {
 
 			expect(processCallCount).toBe(2);
 			expect(frontmatter["ft-calories"]).toBe(200);
+		});
+
+		test("preserves existing frontmatter while nutrient metadata is still pending", async () => {
+			const file = createDailyNote("2024-01-15.md");
+			const frontmatter: Record<string, unknown> = {
+				"ft-calories": 150,
+			};
+			let processCallCount = 0;
+
+			const vault = app.vault as unknown as {
+				cachedRead: (file: TFile) => Promise<string>;
+			};
+			vault.cachedRead = () => Promise.resolve("#food [[apple]] 100g");
+
+			const fileManager = app.fileManager as unknown as {
+				processFrontMatter: (file: TFile, fn: (frontmatter: Record<string, unknown>) => void) => Promise<void>;
+			};
+			fileManager.processFrontMatter = (_file, fn) => {
+				processCallCount += 1;
+				fn(frontmatter);
+				return Promise.resolve();
+			};
+
+			const nutrientCache = {
+				getNutritionData: () => null,
+				hasPendingMetadataFor: (filename: string) => filename === "apple",
+			} as unknown as NutrientCache;
+
+			const service = new FrontmatterTotalsService(app, nutrientCache, settingsService, goalsService);
+
+			service.updateFrontmatterTotals(file);
+			jest.advanceTimersByTime(500);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(processCallCount).toBe(0);
+			expect(frontmatter["ft-calories"]).toBe(150);
+		});
+
+		test("clears stale frontmatter when missing nutrient data is not pending", async () => {
+			const file = createDailyNote("2024-01-15.md");
+			const frontmatter: Record<string, unknown> = {
+				"ft-calories": 150,
+			};
+			let processCallCount = 0;
+
+			const vault = app.vault as unknown as {
+				cachedRead: (file: TFile) => Promise<string>;
+			};
+			vault.cachedRead = () => Promise.resolve("#food [[apple]] 100g");
+
+			const fileManager = app.fileManager as unknown as {
+				processFrontMatter: (file: TFile, fn: (frontmatter: Record<string, unknown>) => void) => Promise<void>;
+			};
+			fileManager.processFrontMatter = (_file, fn) => {
+				processCallCount += 1;
+				fn(frontmatter);
+				return Promise.resolve();
+			};
+
+			const nutrientCache = {
+				getNutritionData: () => null,
+				hasPendingMetadataFor: () => false,
+			} as unknown as NutrientCache;
+
+			const service = new FrontmatterTotalsService(app, nutrientCache, settingsService, goalsService);
+
+			service.updateFrontmatterTotals(file);
+			jest.advanceTimersByTime(500);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(processCallCount).toBe(1);
+			expect(frontmatter["ft-calories"]).toBe(0);
 		});
 	});
 });

--- a/src/__tests__/FrontmatterTotalsService.test.ts
+++ b/src/__tests__/FrontmatterTotalsService.test.ts
@@ -1,4 +1,5 @@
 import {
+	default as FrontmatterTotalsService,
 	extractFrontmatterTotals,
 	nutrientDataToFrontmatterTotals,
 	applyNutrientTotalsToFrontmatter,
@@ -6,7 +7,24 @@ import {
 	FRONTMATTER_PREFIX,
 } from "../FrontmatterTotalsService";
 import { NutrientData } from "../NutritionCalculator";
-import { DEFAULT_FRONTMATTER_FIELD_NAMES, FrontmatterFieldNames } from "../SettingsService";
+import { App, TFile } from "obsidian";
+import GoalsService from "../GoalsService";
+import NutrientCache from "../NutrientCache";
+import {
+	DEFAULT_FRONTMATTER_FIELD_NAMES,
+	FrontmatterFieldNames,
+	SettingsService,
+	DEFAULT_SETTINGS,
+} from "../SettingsService";
+
+function createDailyNote(path: string): TFile {
+	return {
+		path,
+		name: path.split("/").pop() ?? path,
+		basename: (path.split("/").pop() ?? path).replace(/\.md$/, ""),
+		extension: "md",
+	} as unknown as TFile;
+}
 
 describe("FrontmatterTotalsService", () => {
 	describe("FRONTMATTER_PREFIX", () => {
@@ -320,14 +338,14 @@ describe("FrontmatterTotalsService", () => {
 				expect(frontmatter.title).toBe("My Note");
 			});
 
-			test("sets existing values to 0 when totals is empty object", () => {
+			test("preserves existing values when totals is an empty object", () => {
 				const frontmatter: Record<string, unknown> = {
 					"ft-calories": 1000,
 				};
 
 				applyNutrientTotalsToFrontmatter(frontmatter, {});
 
-				expect(frontmatter["ft-calories"]).toBe(0);
+				expect(frontmatter["ft-calories"]).toBe(1000);
 				expect(frontmatter["ft-protein"]).toBeUndefined();
 			});
 
@@ -542,6 +560,106 @@ describe("FrontmatterTotalsService", () => {
 				expect(frontmatter["protein"]).toBe(60);
 				expect(frontmatter["carbohydrates"]).toBe(0);
 			});
+		});
+	});
+
+	describe("update scheduling", () => {
+		let app: App;
+		let settingsService: SettingsService;
+		let goalsService: GoalsService;
+
+		beforeEach(() => {
+			jest.useFakeTimers();
+			app = new App();
+			settingsService = new SettingsService();
+			settingsService.initialize(DEFAULT_SETTINGS);
+			goalsService = new GoalsService(app, "");
+		});
+
+		afterEach(() => {
+			jest.runOnlyPendingTimers();
+			jest.useRealTimers();
+		});
+
+		test("replays nutrient-triggered recalculation after an in-flight write finishes", async () => {
+			const file = createDailyNote("2024-01-15.md");
+			const frontmatter: Record<string, unknown> = {
+				"ft-calories": 50,
+			};
+			let currentCalories = 100;
+			let processCallCount = 0;
+			const pendingWriteResolvers: Array<() => void> = [];
+
+			const vault = app.vault as unknown as {
+				cachedRead: (file: TFile) => Promise<string>;
+				getMarkdownFiles: () => TFile[];
+			};
+			vault.cachedRead = () => Promise.resolve("#food [[apple]] 100g");
+			vault.getMarkdownFiles = () => [file];
+
+			const metadataCache = app.metadataCache as unknown as {
+				getFileCache: (file: TFile) => { links?: Array<{ link: string }> } | null;
+			};
+			metadataCache.getFileCache = requestedFile => {
+				if (requestedFile.path !== file.path) {
+					return null;
+				}
+
+				return {
+					links: [{ link: "apple" }],
+				};
+			};
+
+			const fileManager = app.fileManager as unknown as {
+				processFrontMatter: (file: TFile, fn: (frontmatter: Record<string, unknown>) => void) => Promise<void>;
+			};
+			fileManager.processFrontMatter = async (_file, fn) => {
+				processCallCount += 1;
+				fn(frontmatter);
+
+				if (processCallCount === 1) {
+					await new Promise<void>(resolve => {
+						pendingWriteResolvers.push(resolve);
+					});
+				}
+			};
+
+			const nutrientCache = {
+				getNutritionData: () => ({
+					calories: currentCalories,
+					serving_size: 100,
+					nutrition_per: 100,
+				}),
+			} as unknown as NutrientCache;
+
+			const service = new FrontmatterTotalsService(app, nutrientCache, settingsService, goalsService);
+
+			service.updateFrontmatterTotals(file);
+			jest.advanceTimersByTime(500);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(processCallCount).toBe(1);
+			expect(frontmatter["ft-calories"]).toBe(100);
+
+			currentCalories = 200;
+			service.updateNotesReferencingNutrient("apple");
+
+			const releaseFirstWrite = pendingWriteResolvers[0];
+			if (!releaseFirstWrite) {
+				throw new Error("Expected the first write to be pending");
+			}
+
+			releaseFirstWrite();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			jest.advanceTimersByTime(500);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(processCallCount).toBe(2);
+			expect(frontmatter["ft-calories"]).toBe(200);
 		});
 	});
 });

--- a/src/__tests__/NutrientCache.test.ts
+++ b/src/__tests__/NutrientCache.test.ts
@@ -48,6 +48,7 @@ describe("NutrientCache", () => {
 
 		// Entry should remain until metadata becomes available again
 		expect(cache.getNutrientNames()).toEqual(["apple"]);
+		expect(cache.hasPendingMetadataFor("apple")).toBe(true);
 
 		// Metadata becomes available after parsing finishes
 		frontmatterMap[file.path] = { frontmatter: { name: "apple", calories: 10 } } as unknown as CachedMetadata;
@@ -55,6 +56,7 @@ describe("NutrientCache", () => {
 
 		expect(cache.getNutrientNames()).toEqual(["apple"]);
 		expect(cache.getNutritionData("apple")?.calories).toBe(10);
+		expect(cache.hasPendingMetadataFor("apple")).toBe(false);
 	});
 
 	test("reads nutrition_per from frontmatter", () => {

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -1,5 +1,6 @@
 import FoodTrackerPlugin from "../main";
 import { App, PluginManifest } from "obsidian";
+import GoalsService from "../GoalsService";
 import NutrientCache from "../NutrientCache";
 import { DEFAULT_SETTINGS } from "../SettingsService";
 
@@ -33,18 +34,63 @@ describe("FoodTrackerPlugin", () => {
 		jest.useFakeTimers();
 
 		const initializeSpy = jest.spyOn(NutrientCache.prototype, "initialize").mockImplementation(() => undefined);
-		const delayedPlugin = new FoodTrackerPlugin(new App(), {} as PluginManifest);
+		try {
+			const delayedPlugin = new FoodTrackerPlugin(new App(), {} as PluginManifest);
 
-		await delayedPlugin.onload();
+			await delayedPlugin.onload();
 
-		expect(initializeSpy).not.toHaveBeenCalled();
+			expect(initializeSpy).not.toHaveBeenCalled();
 
-		jest.runOnlyPendingTimers();
-		await Promise.resolve();
+			jest.runOnlyPendingTimers();
+			await Promise.resolve();
 
-		expect(initializeSpy).toHaveBeenCalledTimes(1);
+			expect(initializeSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			initializeSpy.mockRestore();
+			jest.useRealTimers();
+		}
+	});
 
-		initializeSpy.mockRestore();
-		jest.useRealTimers();
+	test("waits for goals before first totals update", async () => {
+		jest.useFakeTimers();
+
+		let resolveGoalsLoad: (() => void) | undefined;
+		const loadGoalsSpy = jest.spyOn(GoalsService.prototype, "loadGoals").mockImplementation(
+			() =>
+				new Promise<void>(resolve => {
+					resolveGoalsLoad = resolve;
+				})
+		);
+		const updateSpy = jest
+			.spyOn(
+				FoodTrackerPlugin.prototype as unknown as { updateNutritionTotal: () => Promise<void> },
+				"updateNutritionTotal"
+			)
+			.mockResolvedValue(undefined);
+
+		try {
+			const delayedPlugin = new FoodTrackerPlugin(new App(), {} as PluginManifest);
+
+			await delayedPlugin.onload();
+			jest.runOnlyPendingTimers();
+			await Promise.resolve();
+
+			expect(loadGoalsSpy).toHaveBeenCalledTimes(1);
+			expect(updateSpy).not.toHaveBeenCalled();
+
+			if (!resolveGoalsLoad) {
+				throw new Error("Expected loadGoals to be pending");
+			}
+
+			resolveGoalsLoad();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(updateSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			updateSpy.mockRestore();
+			loadGoalsSpy.mockRestore();
+			jest.useRealTimers();
+		}
 	});
 });

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -1,5 +1,6 @@
 import FoodTrackerPlugin from "../main";
 import { App, PluginManifest } from "obsidian";
+import NutrientCache from "../NutrientCache";
 import { DEFAULT_SETTINGS } from "../SettingsService";
 
 describe("FoodTrackerPlugin", () => {
@@ -26,5 +27,24 @@ describe("FoodTrackerPlugin", () => {
 		expect(freshPlugin.settings).toBeDefined();
 		expect(freshPlugin.settings.nutrientDirectory).toBe(DEFAULT_SETTINGS.nutrientDirectory);
 		expect(freshPlugin.settings.frontmatterFieldNames).toEqual(DEFAULT_SETTINGS.frontmatterFieldNames);
+	});
+
+	test("defers nutrient cache initialization until layout is ready", async () => {
+		jest.useFakeTimers();
+
+		const initializeSpy = jest.spyOn(NutrientCache.prototype, "initialize").mockImplementation(() => undefined);
+		const delayedPlugin = new FoodTrackerPlugin(new App(), {} as PluginManifest);
+
+		await delayedPlugin.onload();
+
+		expect(initializeSpy).not.toHaveBeenCalled();
+
+		jest.runOnlyPendingTimers();
+		await Promise.resolve();
+
+		expect(initializeSpy).toHaveBeenCalledTimes(1);
+
+		initializeSpy.mockRestore();
+		jest.useRealTimers();
 	});
 });


### PR DESCRIPTION
Fixes #252

## Solution

Daily-note calorie hints and frontmatter totals could drift out of sync during startup or right after nutrient edits because the first cache build could run before metadata was ready. That left some nutrient lookups empty until a plugin reload or full restart.

This change defers the first nutrient cache initialization until the workspace layout is ready, refreshes the active note after the first metadata resolution pass, preserves existing frontmatter when a recalculation yields an empty totals object, and replays nutrient-triggered note updates that arrive while a note is already being written.

## Test plan

- [x] Start Obsidian with the plugin enabled in a vault that already has nutrient notes and confirm the active daily note shows calorie hints and frontmatter totals without reloading the plugin.
- [x] Edit a nutrient note referenced by a daily note and confirm the linked daily note recalculates to the updated values instead of keeping stale totals.
- [x] Verify that a note with no food entries still clears old `ft-*` values, while a note with valid food entries does not get zeroed out during startup or metadata indexing races.
