### PR TITLE
ci: add artifact attestation to release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js
@@ -26,6 +29,13 @@ jobs:
             git status --porcelain
             exit 1
           fi
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds signed SLSA build provenance attestations to the release workflow using `actions/attest@v4`. Each release asset (`main.js`, `manifest.json`, `styles.css`) gets a signed attestation that can be verified with `gh attestation verify`.

## Test plan

- [ ] Cut a test tag and confirm the "Attest build provenance" step succeeds in the Actions run
- [ ] Download `main.js` from the resulting draft release and run `gh attestation verify main.js -R forketyfork/obsidian-food-tracker`
