### PR TITLE
chore(deps): pin obsidian to ^1.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"globals": "^17.6.0",
 		"jest": "^30.4.2",
 		"jest-environment-jsdom": "^30.4.1",
-		"obsidian": "latest",
+		"obsidian": "^1.12.3",
 		"prettier": "^3.8.3",
 		"stylelint": "^17.12.0",
 		"stylelint-config-standard": "^40.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         specifier: ^30.4.1
         version: 30.4.1
       obsidian:
-        specifier: latest
+        specifier: ^1.12.3
         version: 1.12.3(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       prettier:
         specifier: ^3.8.3


### PR DESCRIPTION
## Summary

- Replaces `"obsidian": "latest"` with `"obsidian": "^1.12.3"` in `package.json` so the spec resolves to a concrete semver range.
- Regenerates `pnpm-lock.yaml` (no resolved version change — already at 1.12.3).

## Motivation

Dependabot opens a false-positive alert for CVE-2021-38148 (the `obsidian < 0.12.12` vuln) on every fresh install. Its advisory matcher can't resolve the `latest` dist-tag against semver ranges, so it conservatively flags the dependency even though the lockfile pins 1.12.3 — well above the patched 0.12.12.

A concrete semver range removes the ambiguity. Dependabot will continue to roll the typings forward as new versions ship, gated by the 7-day cooldown policy.

## Test plan

- [x] `pnpm install` and `pnpm build` pass locally.
- [ ] CI build workflow passes on this branch.
- [ ] After merge, the existing CVE-2021-38148 dependabot alert auto-closes.