### PR TITLE
build: stop prettier from reformatting pnpm-lock.yaml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,7 @@ node_modules/
 main.js
 styles.css
 *.json
+
+# pnpm owns this file's formatting; letting prettier rewrite it makes every
+# lockfile update churn the whole file and trips the build's modified-files gate.
+pnpm-lock.yaml


### PR DESCRIPTION
`prettier --write .` rewrites `pnpm-lock.yaml` in prettier's quote style, while pnpm and Dependabot write it in pnpm's. The two serializers fight over the file.

That is not just cosmetic here. The build workflow ends with a **`Fail if build modified files`** gate, so any lockfile arriving in pnpm's format gets rewritten during `pnpm build` and fails CI. This is exactly what happened on #304: once the TypeScript 7 failure was cleared, the build fell over on `M pnpm-lock.yaml`, because Dependabot had regenerated the lockfile wholesale in pnpm's format while `main` carries a prettier-formatted one.

Prettier has no business formatting a generated lockfile, so this ignores it and lets pnpm own the file.

**Note on the committed lockfile:** it stays in its current prettier-formatted state and will normalise to pnpm's own format the next time an update rewrites it. That one update will carry a large one-time reformat diff; every update after it will be clean.

## Test plan

- [ ] Confirm CI is green on this PR (the `Fail if build modified files` step is the one that matters).
- [ ] After merging, check that the next Dependabot npm PR passes the modified-files gate without a manual fix-up.

Verified locally: `pnpm build` exits 0 and leaves the working tree clean, i.e. the modified-files gate passes.
