### PR TITLE
Adopt Obsidian Stylelint configuration

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,14 @@
 {
-	"extends": ["stylelint-config-standard"],
+	"extends": ["stylelint-config-obsidianmd"],
 	"rules": {
-		"declaration-no-important": true
+		"declaration-no-important": true,
+		"plugin/no-unsupported-browser-features": [
+			true,
+			{
+				"severity": "warning",
+				"browsers": ["electron >= 30"],
+				"ignore": ["css-nesting", "css-cascade-layers"]
+			}
+		]
 	}
 }

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ Run the CSS linter:
 pnpm lint:css
 ```
 
+CSS linting uses Obsidian's official Stylelint configuration, targets the plugin's minimum supported Electron version, and treats review warnings as build failures.
+
 Run release workflow checks:
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"test:watch": "pnpm dev && jest --watch",
 		"coverage": "pnpm dev && jest --coverage",
 		"lint": "eslint .",
-		"lint:css": "stylelint \"src/**/*.css\"",
+		"lint:css": "stylelint \"src/**/*.css\" --max-warnings 0",
 		"lint:release": "node scripts/lint-release-assets.mjs",
 		"build": "pnpm typecheck && pnpm lint && pnpm lint:css && pnpm lint:release && pnpm format && pnpm prod && pnpm test",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
@@ -32,7 +32,7 @@
 	"author": "Forketyfork",
 	"license": "MIT",
 	"engines": {
-		"node": "^20.19.0 || ^22.13.0 || >=24"
+		"node": "^22.13.0 || >=24"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
@@ -51,7 +51,7 @@
 		"obsidian": "^1.13.1",
 		"prettier": "^3.9.6",
 		"stylelint": "^17.14.1",
-		"stylelint-config-standard": "^40.0.0",
+		"stylelint-config-obsidianmd": "^0.1.0",
 		"ts-jest": "^29.4.12",
 		"tslib": "^2.8.1",
 		"typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,9 @@ importers:
       stylelint:
         specifier: ^17.14.1
         version: 17.14.1(typescript@6.0.3)
-      stylelint-config-standard:
-        specifier: ^40.0.0
-        version: 40.0.0(stylelint@17.14.1(typescript@6.0.3))
+      stylelint-config-obsidianmd:
+        specifier: ^0.1.0
+        version: 0.1.0(stylelint@17.14.1(typescript@6.0.3))
       ts-jest:
         specifier: ^29.4.12
         version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.1.2))(typescript@6.0.3)
@@ -980,6 +980,10 @@ packages:
     resolution:
       { integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ== }
 
+  "@types/minimatch@3.0.5":
+    resolution:
+      { integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ== }
+
   "@types/node@20.12.12":
     resolution:
       { integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw== }
@@ -1340,10 +1344,20 @@ packages:
       { integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw== }
     engines: { node: ">= 0.4" }
 
+  array-differ@3.0.0:
+    resolution:
+      { integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg== }
+    engines: { node: ">=8" }
+
   array-includes@3.1.9:
     resolution:
       { integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ== }
     engines: { node: ">= 0.4" }
+
+  array-union@2.1.0:
+    resolution:
+      { integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw== }
+    engines: { node: ">=8" }
 
   array.prototype.findlast@1.2.5:
     resolution:
@@ -1374,6 +1388,11 @@ packages:
     resolution:
       { integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ== }
     engines: { node: ">= 0.4" }
+
+  arrify@2.0.1:
+    resolution:
+      { integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug== }
+    engines: { node: ">=8" }
 
   astral-regex@2.0.0:
     resolution:
@@ -1564,6 +1583,10 @@ packages:
     resolution:
       { integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg== }
 
+  core-util-is@1.0.3:
+    resolution:
+      { integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ== }
+
   cosmiconfig@9.0.2:
     resolution:
       { integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg== }
@@ -1587,6 +1610,10 @@ packages:
     resolution:
       { integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg== }
     engines: { node: ">=12" }
+
+  css-tokenize@1.0.1:
+    resolution:
+      { integrity: sha512-gLmmbJdwH9HLY4bcA17lnZ8GgPwEXRbvxBJGHnkiB6gLhRpTzjkjtMIvz7YORGW/Ptv2oMk8b5g+u7mRD6Dd7A== }
 
   css-tree@3.2.1:
     resolution:
@@ -1685,10 +1712,20 @@ packages:
       { integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw== }
     engines: { node: ">=0.10.0" }
 
+  doiuse@6.0.6:
+    resolution:
+      { integrity: sha512-XuPRslcWHhQJ+WjCjimRUcNfhZvOiC0610FsY6WeSlzXvoZYtm6iOpR9K0N4wRoM/lP4i7LatT+IhltAzouSOw== }
+    engines: { node: ">=16" }
+    hasBin: true
+
   dunder-proto@1.0.1:
     resolution:
       { integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A== }
     engines: { node: ">= 0.4" }
+
+  duplexify@4.1.3:
+    resolution:
+      { integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA== }
 
   eastasianwidth@0.2.0:
     resolution:
@@ -1715,6 +1752,10 @@ packages:
     resolution:
       { integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q== }
     engines: { node: ">=14" }
+
+  end-of-stream@1.4.5:
+    resolution:
+      { integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg== }
 
   enhanced-resolve@5.24.5:
     resolution:
@@ -2510,6 +2551,10 @@ packages:
       { integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ== }
     engines: { node: ">= 0.4" }
 
+  isarray@0.0.1:
+    resolution:
+      { integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ== }
+
   isarray@2.0.5:
     resolution:
       { integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw== }
@@ -2938,6 +2983,11 @@ packages:
     resolution:
       { integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA== }
 
+  multimatch@5.0.0:
+    resolution:
+      { integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA== }
+    engines: { node: ">=10" }
+
   nanoid@3.3.18:
     resolution:
       { integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w== }
@@ -3224,6 +3274,15 @@ packages:
     resolution:
       { integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ== }
 
+  readable-stream@1.1.14:
+    resolution:
+      { integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ== }
+
+  readable-stream@3.6.2:
+    resolution:
+      { integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA== }
+    engines: { node: ">= 6" }
+
   reflect.getprototypeof@1.0.10:
     resolution:
       { integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw== }
@@ -3426,6 +3485,11 @@ packages:
       { integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g== }
     engines: { node: ">=0.10.0" }
 
+  source-map@0.7.6:
+    resolution:
+      { integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ== }
+    engines: { node: ">= 12" }
+
   sprintf-js@1.0.3:
     resolution:
       { integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g== }
@@ -3439,6 +3503,10 @@ packages:
     resolution:
       { integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ== }
     engines: { node: ">= 0.4" }
+
+  stream-shift@1.0.3:
+    resolution:
+      { integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ== }
 
   string-length@4.0.2:
     resolution:
@@ -3484,6 +3552,14 @@ packages:
       { integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg== }
     engines: { node: ">= 0.4" }
 
+  string_decoder@0.10.31:
+    resolution:
+      { integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ== }
+
+  string_decoder@1.3.0:
+    resolution:
+      { integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA== }
+
   strip-ansi@6.0.1:
     resolution:
       { integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A== }
@@ -3518,6 +3594,13 @@ packages:
     resolution:
       { integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ== }
 
+  stylelint-config-obsidianmd@0.1.0:
+    resolution:
+      { integrity: sha512-TY2khNT+vN9aMPhGjdmS0t0CHRKyGSfzz3+kpyzzFkyOAILtjWjCEiKGmK3q9RYkkK2EncS5RuYB0EYScDEEkg== }
+    engines: { node: ">= 22" }
+    peerDependencies:
+      stylelint: ^17.0.0
+
   stylelint-config-recommended@18.0.0:
     resolution:
       { integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg== }
@@ -3531,6 +3614,13 @@ packages:
     engines: { node: ">=20.19.0" }
     peerDependencies:
       stylelint: ^17.0.0
+
+  stylelint-no-unsupported-browser-features@8.1.1:
+    resolution:
+      { integrity: sha512-sLEe6NUFoWL2vGt6IKKllQEKfKgVxmvTBFs1JVMHKKLWzxtWAXaqSxJvH+j0URM4vLQQqzC/wXc9Kp3XBNKdBw== }
+    engines: { node: ">=18.12.0" }
+    peerDependencies:
+      stylelint: ">=16.0.2"
 
   stylelint@17.14.1:
     resolution:
@@ -4736,6 +4826,8 @@ snapshots:
 
   "@types/json5@0.0.29": {}
 
+  "@types/minimatch@3.0.5": {}
+
   "@types/node@20.12.12":
     dependencies:
       undici-types: 5.26.5
@@ -5026,6 +5118,8 @@ snapshots:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
 
+  array-differ@3.0.0: {}
+
   array-includes@3.1.9:
     dependencies:
       call-bind: 1.0.9
@@ -5036,6 +5130,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
+
+  array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -5087,6 +5183,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  arrify@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -5255,6 +5353,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  core-util-is@1.0.3: {}
+
   cosmiconfig@9.0.2(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
@@ -5273,6 +5373,11 @@ snapshots:
       which: 2.0.2
 
   css-functions-list@3.3.3: {}
+
+  css-tokenize@1.0.1:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 1.1.14
 
   css-tree@3.2.1:
     dependencies:
@@ -5343,11 +5448,29 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  doiuse@6.0.6:
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
+      css-tokenize: 1.0.1
+      duplexify: 4.1.3
+      multimatch: 5.0.0
+      postcss: 8.5.26
+      source-map: 0.7.6
+      yargs: 17.7.2
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
 
   eastasianwidth@0.2.0: {}
 
@@ -5360,6 +5483,10 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   empathic@2.0.1: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -6194,6 +6321,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@0.0.1: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -6735,6 +6864,14 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multimatch@5.0.0:
+    dependencies:
+      "@types/minimatch": 3.0.5
+      array-differ: 3.0.0
+      array-union: 2.1.0
+      arrify: 2.0.1
+      minimatch: 3.1.5
+
   nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
@@ -6949,6 +7086,19 @@ snapshots:
 
   react-is@19.2.8: {}
 
+  readable-stream@1.1.14:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 0.0.1
+      string_decoder: 0.10.31
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -7126,6 +7276,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
@@ -7136,6 +7288,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-shift@1.0.3: {}
 
   string-length@4.0.2:
     dependencies:
@@ -7204,6 +7358,12 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  string_decoder@0.10.31: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -7222,6 +7382,12 @@ snapshots:
 
   style-mod@4.1.3: {}
 
+  stylelint-config-obsidianmd@0.1.0(stylelint@17.14.1(typescript@6.0.3)):
+    dependencies:
+      stylelint: 17.14.1(typescript@6.0.3)
+      stylelint-config-standard: 40.0.0(stylelint@17.14.1(typescript@6.0.3))
+      stylelint-no-unsupported-browser-features: 8.1.1(stylelint@17.14.1(typescript@6.0.3))
+
   stylelint-config-recommended@18.0.0(stylelint@17.14.1(typescript@6.0.3)):
     dependencies:
       stylelint: 17.14.1(typescript@6.0.3)
@@ -7230,6 +7396,13 @@ snapshots:
     dependencies:
       stylelint: 17.14.1(typescript@6.0.3)
       stylelint-config-recommended: 18.0.0(stylelint@17.14.1(typescript@6.0.3))
+
+  stylelint-no-unsupported-browser-features@8.1.1(stylelint@17.14.1(typescript@6.0.3)):
+    dependencies:
+      browserslist: 4.28.2
+      doiuse: 6.0.6
+      postcss: 8.5.26
+      stylelint: 17.14.1(typescript@6.0.3)
 
   stylelint@17.14.1(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Issue

The generic Stylelint configuration does not reproduce Obsidian's community-review CSS compatibility checks. Unsupported browser features can therefore pass local validation and surface only during plugin review.

## Solution

Adopt Obsidian's official `stylelint-config-obsidianmd`, target Electron 30 for the plugin's minimum supported Obsidian version, and make Stylelint warnings fail the build. Raise the development Node.js requirement to the configuration's supported range and document the CSS validation policy.

## Context

- [Obsidian Stylelint configuration](https://github.com/obsidianmd/stylelint-config)
- [Related YouTrack Fetcher migration](https://github.com/forketyfork/obsidian-youtrack-fetcher/pull/240)
